### PR TITLE
Add flow matching action head

### DIFF
--- a/crossformer/cn/__init__.py
+++ b/crossformer/cn/__init__.py
@@ -29,6 +29,7 @@ from crossformer.data.oxe import ActionDim, HEAD_TO_DATASET
 from crossformer.model.components.action_heads import (
     ActionHead,
     DiffusionActionHead,
+    FlowMatchingActionHead,
     L1ActionHead,
 )
 from crossformer.model.components.tokenizers import ImageTokenizer, LowdimObsTokenizer
@@ -43,6 +44,7 @@ logger.info("Importing crossformer.cn")
 class ModuleE(Enum):
     L1 = L1ActionHead
     DIFFUSION = DiffusionActionHead
+    FLOW = FlowMatchingActionHead
 
 
 @dataclass
@@ -58,6 +60,8 @@ class HeadFactory(CN):
             assert self.steps, "Diffusion steps must be 1+"
         if self.module == ModuleE.L1:
             assert not self.steps, "Diffusion steps must be 0"
+        if self.module == ModuleE.FLOW:
+            assert self.steps, "Flow steps must be 1+"
 
         h = Head[self.name.upper()]
         self.dim = HEAD2SPACE[h]
@@ -73,6 +77,8 @@ class HeadFactory(CN):
         )
         if self.module == ModuleE.DIFFUSION:
             d["diffusion_steps"] = self.steps
+        if self.module == ModuleE.FLOW:
+            d["flow_steps"] = self.steps
 
         return d
 


### PR DESCRIPTION
## Summary
- add a `FlowMatchingActionHead` that trains with a flow-matching loss and integrates a learned velocity field for sampling
- expose the new flow-matching head through the CN head factory so it can be selected from configuration

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68cf6b5bb88c8329b830a77ce653602a