### PR TITLE
Add Grain-based data pipeline implementation

### DIFF
--- a/crossformer/data/grain/README.md
+++ b/crossformer/data/grain/README.md
@@ -1,0 +1,87 @@
+# Plan: Rebuild CrossFormer Data Pipeline with Google Grain
+
+## 1. Objectives and Constraints
+- Replace the current TensorFlow/TFDS-based ingestion in `crossformer.data` with a pipeline built on [Google Grain](https://github.com/google/grain) primitives.
+- Preserve the high-level API exposed by `crossformer.data.dataset` so model training scripts and configs require minimal changes.
+- Support the existing suite of observation, trajectory, and task transforms while leveraging Grain's JAX-first data abstractions.
+- Optimize for scalable multi-host training (pjit/pmap) with deterministic sharding, prefetching, and caching semantics compatible with `jax.Array`.
+- Maintain compatibility with current dataset mixtures, metadata loading, and statistics utilities (normalization, goal relabeling, etc.).
+
+## 2. Proposed Directory Layout (`crossformer/data/grain`)
+```
+crossformer/data/grain/
+  __init__.py              # high-level API surface that mirrors `dataset.py` entry-points
+  builders.py              # dataset specification parsing + Grain Dataset/BatchDataset builders
+  pipelines.py             # reusable pipeline compositions (train/eval) with windowing, relabeling, etc.
+  transforms.py            # Grain-compatible wrappers for existing trajectory/observation transforms
+  threading.py             # thread pool & async helpers replacing `allocate_threads`
+  sharding.py              # pjit/pmap sharding utilities and per-host sampling logic
+  metadata.py              # statistics loading, caching, and normalization metadata integration
+  utils.py                 # shared helpers (key mapping, structure flattening, spec validation)
+  tests/
+    test_builders.py
+    test_pipelines.py
+```
+
+## 3. Migration Strategy
+1. **Audit Current Pipeline Usage**
+   - Inventory public functions/classes imported from `crossformer.data.dataset` by training/inference code.
+   - Document the expected `dl.DLataset`-like behaviors (streaming, `traj_map`, filtering, batching, etc.).
+   - Map TensorFlow-specific utilities (e.g., `tf.data.AUTOTUNE`, `dataset.filter`) to Grain equivalents.
+
+2. **Establish Core Grain Builders**
+   - Design a `DatasetConfig` dataclass capturing source (TFDS, local files, GCS), splits, mixture weights, and preprocessing flags.
+   - Implement builders that translate `DatasetConfig` into `grain.Dataset` pipelines using `grain.sources` and `grain.random` for deterministic sampling.
+   - Provide adapters for legacy dataset descriptors (e.g., JSON mixture configs) to fill `DatasetConfig` instances.
+
+3. **Reimplement Transform API**
+   - Translate existing trajectory transforms (`traj_transforms`) into pure Python/JAX functions that operate on nested dicts/pytrees.
+   - Wrap them with Grain's `map`/`flat_map`/`window` operators, ensuring statelessness and compatibility with multi-threaded execution.
+   - Ensure observation transforms (`obs_transforms`) can run either in Python or JAX (using `jax.vmap` where beneficial).
+   - Move TensorFlow-dependent logic (string tensors, `tf.image`) to NumPy/JAX equivalents or `tensorflow_text` replacements.
+
+4. **Chunking and Windowing**
+   - Replace `traj_map(...chunk_act_obs...)` with Grain's windowing primitives, emitting batched `jax.numpy` arrays.
+   - Add utilities for overlapping windows, action horizons, and optional override window sizes.
+   - Validate that padding, mask generation, and subsampling semantics match the TensorFlow version.
+
+5. **Goal Relabeling & Task Augmentation**
+   - Port `goal_relabeling` and `task_augmentation` functions to be framework-agnostic (pure Python/JAX) if they are not already.
+   - Integrate them into Grain pipelines via map/filter steps with host-level randomness managed by `jax.random` keys.
+
+6. **Normalization and Statistics**
+   - Reuse `get_dataset_statistics` and related utilities, replacing any TensorFlow ops with NumPy/JAX operations.
+   - Cache normalization metadata per dataset mixture and expose it alongside pipeline constructors.
+
+7. **Threading, Prefetch, and Sharding**
+   - Implement per-host sharding and deterministic mixing via `grain.experimental.distribute` or custom sharding helpers.
+   - Provide async prefetch to device using `jax.device_put_sharded` or `jax.experimental.multihost_utils`.
+   - Replace `allocate_threads` with a Grain-native threadpool configuration that still honors user-provided parallelism hints.
+
+8. **High-Level Entry Points**
+   - Expose `get_dataset`, `get_dataloader`, and `build_dataset_from_config` from `crossformer.data.grain.__init__` matching current signatures.
+   - Provide feature flags allowing gradual migration (e.g., `use_grain=True`).
+
+9. **Testing & Validation**
+   - Unit tests for builders and pipelines using small fake datasets to ensure chunking, padding, and goal relabeling match expectations.
+   - Golden tests comparing output structure/stats of TensorFlow vs Grain pipelines on a shared toy dataset.
+   - Performance regression checks (throughput, latency) under representative batch sizes.
+
+## 4. Integration Plan
+- Add configuration hooks so training scripts can select the Grain pipeline via config (e.g., `data_backend: "grain"`).
+- Update documentation (`docs/`) to describe new backend, installation requirements (`pip install grain[jax]`).
+- Provide migration guide for custom datasets pointing to new builder API.
+- Once feature-parity is confirmed, deprecate TensorFlow pipeline and schedule removal.
+
+## 5. Open Questions / Risks
+- Grain maturity for large-scale trajectory datasets; may require custom sources (e.g., WebDataset-like readers).
+- Ensuring compatibility with language-conditioned trajectories where text processing previously relied on TensorFlow ops.
+- Managing randomness between Python threads & JAX PRNG to avoid data duplication across devices.
+- Need to evaluate how `dlimp` integration changes—either replace with Grain or build adapters.
+
+## 6. Milestones
+1. **Week 1:** Audit + scaffolding (`builders.py`, configs, simple TFDS loader -> Grain`).
+2. **Week 2:** Port trajectory/observation transforms, chunking, normalization.
+3. **Week 3:** Implement sharding, prefetch, and integration hooks; add documentation.
+4. **Week 4:** Comprehensive testing, benchmarking, parity validation, and rollout toggles.
+

--- a/crossformer/data/grain/__init__.py
+++ b/crossformer/data/grain/__init__.py
@@ -1,0 +1,20 @@
+"""Google Grain based data pipeline for CrossFormer."""
+
+from crossformer.data.grain.builders import GrainDatasetConfig
+from crossformer.data.grain.pipelines import (
+    apply_frame_transforms,
+    apply_trajectory_transforms,
+    GrainDataset,
+    make_interleaved_dataset,
+    make_single_dataset,
+)
+
+__all__ = [
+    "GrainDatasetConfig",
+    "GrainDataset",
+    "apply_frame_transforms",
+    "apply_trajectory_transforms",
+    "make_single_dataset",
+    "make_interleaved_dataset",
+]
+

--- a/crossformer/data/grain/builders.py
+++ b/crossformer/data/grain/builders.py
@@ -1,0 +1,224 @@
+"""Builders converting raw data sources into Grain datasets."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+import fnmatch
+import json
+from typing import Any
+
+import numpy as np
+import grain.python as gp
+
+from crossformer.data.grain import metadata, utils
+from crossformer.utils.spec import ModuleSpec
+
+
+def _resolve_callable(spec_or_fn: ModuleSpec | Callable | None) -> Callable | None:
+    if spec_or_fn is None:
+        return None
+    if isinstance(spec_or_fn, Mapping) and set(spec_or_fn.keys()) == {
+        "module",
+        "name",
+        "args",
+        "kwargs",
+    }:
+        return ModuleSpec.instantiate(spec_or_fn)  # type: ignore[arg-type]
+    if not callable(spec_or_fn):
+        raise TypeError(f"Expected callable or ModuleSpec, got {type(spec_or_fn)!r}")
+    return spec_or_fn  # type: ignore[return-value]
+
+
+def _resolve_source(
+    source: Sequence[dict] | gp.RandomAccessDataSource | Callable[[], Any]
+) -> Sequence[dict] | gp.RandomAccessDataSource:
+    if callable(source):
+        return _resolve_source(source())
+    if isinstance(source, gp.RandomAccessDataSource):
+        return source
+    if isinstance(source, Sequence):
+        return source
+    raise TypeError(
+        "Data source must be a Sequence, RandomAccessDataSource, or callable returning one."
+    )
+
+
+def _iter_source(source: Sequence[dict] | gp.RandomAccessDataSource) -> Iterable[dict]:
+    for index in range(len(source)):  # type: ignore[arg-type]
+        element = source[index]
+        if hasattr(element, "data"):
+            element = element.data
+        yield utils.clone_structure(element)
+
+
+def _sample_match_key(traj: Mapping[str, Any], template: str) -> Any:
+    matches = [key for key in traj if fnmatch.fnmatch(key, template)]
+    if not matches:
+        raise ValueError(f"No keys match template {template!r}; available keys: {traj.keys()}")
+    return traj[matches[0]]
+
+
+@dataclass
+class GrainDatasetConfig:
+    name: str
+    source: Sequence[dict] | gp.RandomAccessDataSource | Callable[[], Any]
+    standardize_fn: ModuleSpec | Callable | None = None
+    image_obs_keys: Mapping[str, str | None] = field(default_factory=dict)
+    depth_obs_keys: Mapping[str, str | None] = field(default_factory=dict)
+    proprio_obs_keys: Mapping[str, str | None] | None = None
+    proprio_obs_dims: Mapping[str, int] | None = None
+    language_key: str | None = None
+    action_proprio_normalization_type: str = metadata.NormalizationType.NORMAL
+    dataset_statistics: metadata.DatasetStatistics | Mapping[str, Any] | str | None = None
+    statistics_save_dir: str | None = None
+    force_recompute_dataset_statistics: bool = False
+    action_normalization_mask: Sequence[bool] | None = None
+    filter_fns: Sequence[ModuleSpec | Callable[[dict], bool]] = ()
+    skip_norm: bool = False
+    skip_norm_keys: Sequence[str] = ()
+    seed: int = 0
+
+
+def _restructure_trajectory(
+    traj: dict,
+    *,
+    name: str,
+    standardize: Callable | None,
+    config: GrainDatasetConfig,
+) -> dict:
+    traj = utils.clone_structure(traj)
+    if standardize is not None:
+        traj = standardize(traj)
+    if "observation" not in traj or "action" not in traj:
+        raise ValueError("Trajectory must contain 'observation' and 'action' keys.")
+
+    action = np.asarray(traj["action"], dtype=np.float32)
+    traj_len = action.shape[0]
+    if traj_len == 0:
+        return {}
+
+    old_obs = traj["observation"]
+    new_obs: dict[str, Any] = {}
+    for new, old in config.image_obs_keys.items():
+        key = f"image_{new}"
+        if old is None:
+            new_obs[key] = np.full((traj_len,), "", dtype=object)
+        else:
+            new_obs[key] = np.asarray(old_obs[old])
+    for new, old in config.depth_obs_keys.items():
+        key = f"depth_{new}"
+        if old is None:
+            new_obs[key] = np.full((traj_len,), "", dtype=object)
+        else:
+            new_obs[key] = np.asarray(old_obs[old])
+    if config.proprio_obs_keys is not None:
+        if config.proprio_obs_dims is None:
+            raise ValueError("proprio_obs_dims must be provided when proprio_obs_keys is set.")
+        for new, old in config.proprio_obs_keys.items():
+            key = f"proprio_{new}"
+            if old is None:
+                new_obs[key] = np.zeros((traj_len, config.proprio_obs_dims[new]), dtype=np.float32)
+            else:
+                new_obs[key] = np.asarray(old_obs[old], dtype=np.float32)
+
+    new_obs["timestep"] = np.arange(traj_len, dtype=np.int32)
+
+    task = {}
+    if config.language_key is not None:
+        language = _sample_match_key(traj, config.language_key)
+        language = np.asarray(language)
+        if language.shape == ():
+            language = np.repeat(language, traj_len)
+        if language.shape[0] != traj_len:
+            language = np.broadcast_to(language, (traj_len,))
+        task["language_instruction"] = language.astype(object)
+
+    return {
+        "observation": new_obs,
+        "task": task,
+        "action": action,
+        "dataset_name": np.repeat(name, traj_len),
+    }
+
+
+def _load_dataset_statistics(
+    config: GrainDatasetConfig,
+    proprio_keys: Sequence[str],
+    trajectories: Sequence[dict],
+) -> metadata.DatasetStatistics:
+    if isinstance(config.dataset_statistics, metadata.DatasetStatistics):
+        return config.dataset_statistics
+    if isinstance(config.dataset_statistics, Mapping):
+        return metadata.DatasetStatistics.from_json(config.dataset_statistics)
+    if isinstance(config.dataset_statistics, str):
+        with open(config.dataset_statistics, "r") as f:
+            return metadata.DatasetStatistics.from_json(json.load(f))
+
+    hash_dependencies = [
+        config.name,
+        str(sorted(config.image_obs_keys.items())),
+        str(sorted(config.depth_obs_keys.items())),
+        str(sorted(proprio_keys)),
+    ]
+    return metadata.compute_dataset_statistics(
+        trajectories,
+        proprio_keys=proprio_keys,
+        hash_dependencies=hash_dependencies,
+        save_dir=config.statistics_save_dir,
+        force_recompute=config.force_recompute_dataset_statistics,
+    )
+
+
+def build_trajectory_dataset(
+    config: GrainDatasetConfig,
+) -> tuple[gp.MapDataset, metadata.DatasetStatistics]:
+    """Builds a :class:`grain.MapDataset` emitting standardized trajectories."""
+
+    source = _resolve_source(config.source)
+    standardize = _resolve_callable(config.standardize_fn)
+    filter_functions = [fn for fn in (_resolve_callable(fn) for fn in config.filter_fns) if fn]
+
+    processed: list[dict] = []
+    for raw_traj in _iter_source(source):
+        if filter_functions and any(not fn(raw_traj) for fn in filter_functions):
+            continue
+        traj = _restructure_trajectory(
+            raw_traj,
+            name=config.name,
+            standardize=standardize,
+            config=config,
+        )
+        if not traj:
+            continue
+        processed.append(traj)
+
+    proprio_keys = [
+        f"proprio_{key}"
+        for key, value in (config.proprio_obs_keys or {}).items()
+        if value is not None
+    ]
+    stats = _load_dataset_statistics(config, proprio_keys, processed)
+
+    if not config.skip_norm:
+        mask = config.action_normalization_mask
+        normalized = [
+            metadata.normalize_action_and_proprio(
+                traj,
+                metadata=stats,
+                normalization_type=config.action_proprio_normalization_type,
+                proprio_keys=proprio_keys,
+                action_mask=mask,
+                skip_norm_keys=config.skip_norm_keys,
+            )
+            for traj in processed
+        ]
+    else:
+        normalized = processed
+
+    dataset = gp.MapDataset.range(len(normalized)).map(
+        lambda idx: utils.clone_structure(normalized[idx])
+    )
+    dataset.dataset_statistics = stats  # type: ignore[attr-defined]
+    return dataset, stats
+

--- a/crossformer/data/grain/metadata.py
+++ b/crossformer/data/grain/metadata.py
@@ -1,0 +1,204 @@
+"""Dataset metadata utilities for the Grain pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+import numpy as np
+
+from crossformer.data.grain import utils
+
+
+EPS = 1e-8
+
+
+@dataclass
+class ArrayStatistics:
+    mean: np.ndarray
+    std: np.ndarray
+    maximum: np.ndarray
+    minimum: np.ndarray
+    p99: np.ndarray
+    p01: np.ndarray
+
+    def to_json(self) -> dict:
+        return {
+            "mean": self.mean.tolist(),
+            "std": self.std.tolist(),
+            "max": self.maximum.tolist(),
+            "min": self.minimum.tolist(),
+            "p99": self.p99.tolist(),
+            "p01": self.p01.tolist(),
+        }
+
+    @classmethod
+    def from_json(cls, data: Mapping[str, Sequence[float]]) -> "ArrayStatistics":
+        return cls(
+            mean=np.asarray(data["mean"], dtype=np.float32),
+            std=np.asarray(data["std"], dtype=np.float32),
+            maximum=np.asarray(data["max"], dtype=np.float32),
+            minimum=np.asarray(data["min"], dtype=np.float32),
+            p99=np.asarray(data["p99"], dtype=np.float32),
+            p01=np.asarray(data["p01"], dtype=np.float32),
+        )
+
+
+@dataclass
+class DatasetStatistics:
+    action: ArrayStatistics
+    proprio: dict[str, ArrayStatistics]
+    num_transitions: int
+    num_trajectories: int
+
+    def to_json(self) -> dict:
+        return {
+            "action": self.action.to_json(),
+            "proprio": {k: v.to_json() for k, v in self.proprio.items()},
+            "num_transitions": self.num_transitions,
+            "num_trajectories": self.num_trajectories,
+        }
+
+    @classmethod
+    def from_json(cls, data: Mapping[str, object]) -> "DatasetStatistics":
+        proprio = {
+            key: ArrayStatistics.from_json(value)  # type: ignore[arg-type]
+            for key, value in data.get("proprio", {}).items()  # type: ignore[union-attr]
+        }
+        return cls(
+            action=ArrayStatistics.from_json(data["action"]),  # type: ignore[arg-type]
+            proprio=proprio,
+            num_transitions=int(data.get("num_transitions", 0)),
+            num_trajectories=int(data.get("num_trajectories", 0)),
+        )
+
+
+class NormalizationType(str):
+    NORMAL = "normal"
+    BOUNDS = "bounds"
+
+
+def _stats_from_array(array: np.ndarray) -> ArrayStatistics:
+    return ArrayStatistics(
+        mean=array.mean(axis=0),
+        std=array.std(axis=0),
+        maximum=array.max(axis=0),
+        minimum=array.min(axis=0),
+        p99=np.quantile(array, 0.99, axis=0),
+        p01=np.quantile(array, 0.01, axis=0),
+    )
+
+
+def _cache_path(hash_dependencies: Iterable[str], save_dir: str | Path | None) -> Path:
+    key = "".join(hash_dependencies).encode("utf-8")
+    unique_hash = hashlib.sha256(key, usedforsecurity=False).hexdigest()
+    if save_dir is not None:
+        return Path(save_dir) / f"dataset_statistics_{unique_hash}.json"
+    cache_dir = Path.home() / ".cache" / "crossformer"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"dataset_statistics_{unique_hash}.json"
+
+
+def compute_dataset_statistics(
+    trajectories: Iterable[dict],
+    *,
+    proprio_keys: Sequence[str],
+    hash_dependencies: Sequence[str],
+    save_dir: str | Path | None = None,
+    force_recompute: bool = False,
+) -> DatasetStatistics:
+    """Computes statistics for trajectories or loads cached values."""
+
+    cache_path = _cache_path(hash_dependencies, save_dir)
+    if cache_path.exists() and not force_recompute:
+        with cache_path.open("r") as f:
+            return DatasetStatistics.from_json(json.load(f))
+
+    actions = []
+    proprio: dict[str, list[np.ndarray]] = {key: [] for key in proprio_keys}
+    num_transitions = 0
+    num_trajectories = 0
+
+    for traj in trajectories:
+        action = utils.ensure_numpy(traj["action"]).astype(np.float32)
+        actions.append(action)
+        num_transitions += action.shape[0]
+        num_trajectories += 1
+        obs = traj.get("observation", {})
+        for key in proprio_keys:
+            if key in obs:
+                proprio[key].append(utils.ensure_numpy(obs[key]).astype(np.float32))
+
+    if not actions:
+        raise ValueError("Cannot compute statistics from an empty dataset.")
+    action_array = np.concatenate(actions, axis=0)
+    proprio_stats = {
+        key: _stats_from_array(np.concatenate(values, axis=0))
+        for key, values in proprio.items()
+        if values
+    }
+    stats = DatasetStatistics(
+        action=_stats_from_array(action_array),
+        proprio=proprio_stats,
+        num_transitions=num_transitions,
+        num_trajectories=num_trajectories,
+    )
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with cache_path.open("w") as f:
+        json.dump(stats.to_json(), f)
+    return stats
+
+
+def normalize_action_and_proprio(
+    traj: dict,
+    *,
+    metadata: DatasetStatistics,
+    normalization_type: str,
+    proprio_keys: Sequence[str],
+    action_mask: Sequence[bool] | None = None,
+    skip_norm_keys: Sequence[str] = (),
+) -> dict:
+    """Normalizes actions and proprioceptive observations."""
+
+    traj = utils.clone_structure(traj)
+    action = utils.ensure_numpy(traj["action"]).astype(np.float32)
+    if normalization_type == NormalizationType.NORMAL:
+        mean = metadata.action.mean
+        std = np.maximum(metadata.action.std, EPS)
+        normalized = (action - mean) / std
+    elif normalization_type == NormalizationType.BOUNDS:
+        span = np.maximum(metadata.action.maximum - metadata.action.minimum, EPS)
+        normalized = 2.0 * (action - metadata.action.minimum) / span - 1.0
+    else:
+        raise ValueError(f"Unknown normalization type: {normalization_type}")
+
+    if action_mask is not None:
+        action_mask_array = np.asarray(action_mask, dtype=bool)
+        if action_mask_array.shape[-1] != normalized.shape[-1]:
+            raise ValueError(
+                "Length of action mask does not match action dimension."
+            )
+        normalized = np.where(action_mask_array, normalized, action)
+    traj["action"] = normalized
+
+    obs = utils.as_dict(traj.get("observation"))
+    for key in proprio_keys:
+        if key not in obs or key in skip_norm_keys:
+            continue
+        if key not in metadata.proprio:
+            continue
+        value = utils.ensure_numpy(obs[key]).astype(np.float32)
+        stats = metadata.proprio[key]
+        if normalization_type == NormalizationType.NORMAL:
+            mean = stats.mean
+            std = np.maximum(stats.std, EPS)
+            obs[key] = (value - mean) / std
+        else:
+            span = np.maximum(stats.maximum - stats.minimum, EPS)
+            obs[key] = 2.0 * (value - stats.minimum) / span - 1.0
+    traj["observation"] = obs
+    return traj
+

--- a/crossformer/data/grain/pipelines.py
+++ b/crossformer/data/grain/pipelines.py
@@ -1,0 +1,288 @@
+"""High level utilities for constructing Grain based data pipelines."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import grain.python as gp
+import grain.python.experimental as gpexp
+
+from crossformer.data.grain import builders, transforms
+from crossformer.utils.spec import ModuleSpec
+
+
+def _resolve_callable(spec_or_fn: ModuleSpec | Callable | None) -> Callable | None:
+    if spec_or_fn is None:
+        return None
+    if isinstance(spec_or_fn, Mapping) and set(spec_or_fn.keys()) == {
+        "module",
+        "name",
+        "args",
+        "kwargs",
+    }:
+        return ModuleSpec.instantiate(spec_or_fn)  # type: ignore[arg-type]
+    if not callable(spec_or_fn):
+        raise TypeError(f"Expected callable or ModuleSpec, got {type(spec_or_fn)!r}")
+    return spec_or_fn  # type: ignore[return-value]
+
+
+def _filter_language_present(traj: dict) -> bool:
+    language = traj.get("task", {}).get("language_instruction")
+    if language is None:
+        return False
+    language = np.asarray(language)
+    return np.any(language != "")
+
+
+def apply_trajectory_transforms(
+    dataset: gp.MapDataset,
+    *,
+    train: bool,
+    window_size: int = 1,
+    action_horizon: int = 1,
+    override_window_size: int | None = None,
+    goal_relabeling_strategy: str | None = None,
+    goal_relabeling_kwargs: Mapping[str, Any] | None = None,
+    subsample_length: int | None = None,
+    skip_unlabeled: bool = False,
+    max_action: float | None = None,
+    max_proprio: float | None = None,
+    max_action_dim: int | None = None,
+    max_proprio_dim: int | None = None,
+    post_chunk_transforms: Sequence[ModuleSpec | Callable] = (),
+    head_to_dataset: Mapping[str, Sequence[str]] | None = None,
+    seed: int = 0,
+) -> gp.MapDataset:
+    """Applies trajectory level transforms mirroring the TensorFlow pipeline."""
+
+    if skip_unlabeled:
+        dataset = dataset.filter(_filter_language_present)
+
+    if max_action is not None:
+        dataset = dataset.filter(
+            lambda traj: np.all(np.abs(np.asarray(traj["action"])) <= max_action)
+        )
+
+    if max_proprio is not None:
+        def _proprio_within_bounds(traj: dict) -> bool:
+            for key, value in traj.get("observation", {}).items():
+                if key.startswith("proprio"):
+                    if not np.all(np.abs(np.asarray(value)) <= max_proprio):
+                        return False
+            return True
+
+        dataset = dataset.filter(_proprio_within_bounds)
+
+    dataset = dataset.map(transforms.add_pad_mask_dict)
+    dataset = dataset.map(
+        lambda traj: transforms.pad_actions_and_proprio(
+            traj,
+            max_action_dim=max_action_dim,
+            max_proprio_dim=max_proprio_dim,
+        )
+    )
+
+    dataset = dataset.seed(seed)
+
+    if goal_relabeling_strategy is not None:
+        if goal_relabeling_strategy != "uniform":
+            raise ValueError(
+                f"Unsupported goal relabeling strategy: {goal_relabeling_strategy}"
+            )
+        kwargs = goal_relabeling_kwargs or {}
+        dataset = dataset.random_map(
+            lambda traj, rng: transforms.uniform_goal_relabel(traj, rng=rng, **kwargs)
+        )
+
+    if train and subsample_length is not None:
+        dataset = dataset.random_map(
+            lambda traj, rng: transforms.subsample(traj, length=subsample_length, rng=rng)
+        )
+
+    dataset = dataset.map(
+        lambda traj: transforms.chunk_action_and_observation(
+            traj,
+            window_size=window_size,
+            action_horizon=action_horizon,
+            override_window_size=override_window_size,
+        )
+    )
+
+    dataset = dataset.map(
+        lambda traj: transforms.add_head_action_mask(
+            traj, head_to_dataset=head_to_dataset
+        )
+    )
+
+    for transform in post_chunk_transforms:
+        callable_transform = _resolve_callable(transform)
+        if callable_transform is None:
+            continue
+        dataset = dataset.map(callable_transform)
+
+    return dataset
+
+
+class _FlattenIterDataset(gp.IterDataset):
+    def __init__(self, parent: gp.MapDataset):
+        super().__init__(parent)
+
+    def __iter__(self):
+        parent_iter = self._parent.__iter__()
+        for trajectory in parent_iter:
+            yield from transforms.flatten_trajectory(trajectory)
+
+
+class _BufferShuffleIterDataset(gp.IterDataset):
+    def __init__(self, parent: gp.IterDataset, buffer_size: int, seed: int):
+        super().__init__(parent)
+        self._buffer_size = buffer_size
+        self._seed = seed
+
+    def __iter__(self):
+        rng = np.random.default_rng(self._seed)
+        buffer = []
+        for element in self._parent:
+            buffer.append(element)
+            if len(buffer) >= self._buffer_size:
+                rng.shuffle(buffer)
+                while buffer:
+                    yield buffer.pop()
+        if buffer:
+            rng.shuffle(buffer)
+            while buffer:
+                yield buffer.pop()
+
+
+def apply_frame_transforms(
+    dataset: gp.IterDataset,
+    frame_transforms: Sequence[ModuleSpec | Callable] = (),
+) -> gp.IterDataset:
+    """Applies frame level transforms as simple map operations."""
+
+    for transform in frame_transforms:
+        callable_transform = _resolve_callable(transform)
+        if callable_transform is None:
+            continue
+        dataset = dataset.map(callable_transform)
+    return dataset
+
+
+@dataclass
+class GrainDataset:
+    dataset: gp.IterDataset
+    statistics: Any
+
+
+def make_single_dataset(
+    config: builders.GrainDatasetConfig,
+    *,
+    train: bool,
+    traj_transform_kwargs: dict[str, Any] | None = None,
+    frame_transforms: Sequence[ModuleSpec | Callable] = (),
+    shuffle_buffer_size: int | None = None,
+    batch_size: int | None = None,
+    drop_remainder: bool = False,
+    seed: int = 0,
+) -> GrainDataset:
+    """Builds a dataset of frames for a single dataset configuration."""
+
+    traj_dataset, stats = builders.build_trajectory_dataset(config)
+    traj_kwargs = dict(traj_transform_kwargs or {})
+    traj_dataset = apply_trajectory_transforms(
+        traj_dataset, train=train, seed=seed, **traj_kwargs
+    )
+
+    frame_dataset: gp.IterDataset = _FlattenIterDataset(traj_dataset)
+    frame_dataset = apply_frame_transforms(frame_dataset, frame_transforms)
+
+    if shuffle_buffer_size and shuffle_buffer_size > 1:
+        frame_dataset = _BufferShuffleIterDataset(
+            frame_dataset, buffer_size=shuffle_buffer_size, seed=seed
+        )
+
+    if train:
+        frame_dataset = frame_dataset.repeat()
+
+    if batch_size is not None:
+        frame_dataset = frame_dataset.batch(batch_size, drop_remainder=drop_remainder)
+
+    frame_dataset.dataset_statistics = stats  # type: ignore[attr-defined]
+    return GrainDataset(dataset=frame_dataset, statistics=stats)
+
+
+def make_interleaved_dataset(
+    configs: Sequence[builders.GrainDatasetConfig],
+    *,
+    train: bool,
+    sample_weights: Sequence[float] | None = None,
+    shuffle_buffer_size: int = 1,
+    traj_transform_kwargs: dict[str, Any] | None = None,
+    frame_transforms: Sequence[ModuleSpec | Callable] = (),
+    batch_size: int | None = None,
+    drop_remainder: bool = False,
+    seed: int = 0,
+) -> GrainDataset:
+    """Creates a weighted mixture of datasets similar to the TensorFlow pipeline."""
+
+    if not configs:
+        raise ValueError("At least one dataset configuration must be provided.")
+
+    datasets = []
+    statistics = {}
+    for cfg in configs:
+        ds = make_single_dataset(
+            cfg,
+            train=train,
+            traj_transform_kwargs=traj_transform_kwargs,
+            frame_transforms=frame_transforms,
+            shuffle_buffer_size=None,
+            batch_size=None,
+            seed=seed,
+        )
+        datasets.append(ds.dataset)
+        statistics[cfg.name] = ds.statistics
+
+    if sample_weights is None:
+        weights = np.ones(len(datasets), dtype=np.float32)
+    else:
+        weights = np.asarray(sample_weights, dtype=np.float32)
+        if weights.shape[0] != len(datasets):
+            raise ValueError("Number of sample weights must match number of datasets.")
+    weights = weights / weights.sum()
+
+    class _MixtureIterDataset(gp.IterDataset):
+        def __init__(self, children: Sequence[gp.IterDataset], probs: np.ndarray):
+            super().__init__(children)
+            self._children = children
+            self._probs = probs
+
+        def __iter__(self):
+            rng = np.random.default_rng(seed)
+            child_iters = [iter(child) for child in self._children]
+            while True:
+                choice = rng.choice(len(child_iters), p=self._probs)
+                try:
+                    yield next(child_iters[choice])
+                except StopIteration:
+                    return
+
+    mixture_dataset: gp.IterDataset = _MixtureIterDataset(datasets, weights)
+
+    if shuffle_buffer_size and shuffle_buffer_size > 1:
+        mixture_dataset = _BufferShuffleIterDataset(
+            mixture_dataset, buffer_size=shuffle_buffer_size, seed=seed
+        )
+
+    if train:
+        mixture_dataset = mixture_dataset.repeat()
+
+    if batch_size is not None:
+        mixture_dataset = mixture_dataset.batch(batch_size, drop_remainder=drop_remainder)
+
+    mixture_dataset.dataset_statistics = statistics  # type: ignore[attr-defined]
+    return GrainDataset(dataset=mixture_dataset, statistics=statistics)
+

--- a/crossformer/data/grain/sharding.py
+++ b/crossformer/data/grain/sharding.py
@@ -1,0 +1,31 @@
+"""Utility functions for configuring sharding of Grain data sources."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import grain.python as gp
+
+
+def create_shard_options(
+    *,
+    shard_count: Optional[int] = None,
+    shard_index: Optional[int] = None,
+    drop_remainder: bool = False,
+    use_jax_process: bool = False,
+) -> gp.ShardOptions:
+    """Returns :class:`grain.python.ShardOptions` according to the strategy."""
+
+    if use_jax_process:
+        return gp.ShardByJaxProcess(drop_remainder=drop_remainder)
+
+    if shard_count is None:
+        return gp.ShardOptions(shard_index=0, shard_count=1, drop_remainder=drop_remainder)
+    if shard_index is None:
+        raise ValueError("shard_index must be provided when shard_count is set")
+    return gp.ShardOptions(
+        shard_index=int(shard_index),
+        shard_count=int(shard_count),
+        drop_remainder=drop_remainder,
+    )
+

--- a/crossformer/data/grain/tests/test_pipelines.py
+++ b/crossformer/data/grain/tests/test_pipelines.py
@@ -1,0 +1,112 @@
+"""Unit tests for the Grain data pipeline."""
+
+from __future__ import annotations
+
+import itertools
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from crossformer.data.grain import builders, make_interleaved_dataset, make_single_dataset
+
+
+def _make_trajectory(length: int, *, language: str, offset: float = 0.0) -> dict:
+    return {
+        "observation": {
+            "rgb": np.array([f"img_{i}" for i in range(length)], dtype=object),
+            "proprio": np.stack([
+                np.linspace(0.0 + offset, 1.0 + offset, num=2, dtype=np.float32)
+                for _ in range(length)
+            ]),
+        },
+        "action": np.stack(
+            [
+                np.array([i + offset, i + 1 + offset], dtype=np.float32)
+                for i in range(length)
+            ]
+        ),
+        "language": np.array([language] * length, dtype=object),
+    }
+
+
+def _make_config(name: str, *, trajectories: list[dict], tmp_path: Path) -> builders.GrainDatasetConfig:
+    return builders.GrainDatasetConfig(
+        name=name,
+        source=trajectories,
+        image_obs_keys={"main": "rgb"},
+        depth_obs_keys={},
+        proprio_obs_keys={"arm": "proprio"},
+        proprio_obs_dims={"arm": 2},
+        language_key="language",
+        statistics_save_dir=str(tmp_path / f"stats_{name}"),
+    )
+
+
+class GrainPipelineTest(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_single_dataset_chunking(self):
+        trajectories = [
+            _make_trajectory(3, language="pick"),
+            _make_trajectory(2, language="", offset=0.5),
+        ]
+        config = _make_config("toy", trajectories=trajectories, tmp_path=self.tmp_path)
+        result = make_single_dataset(
+            config,
+            train=False,
+            traj_transform_kwargs={
+                "window_size": 2,
+                "action_horizon": 2,
+                "skip_unlabeled": True,
+            },
+        )
+
+        frames = list(result.dataset)
+        # Only the labeled trajectory remains after skip_unlabeled.
+        self.assertEqual(len(frames), 3)
+        for frame in frames:
+            self.assertEqual(frame["action"].shape, (2, 2, 2))
+            self.assertEqual(frame["action_pad_mask"].shape, (2, 2, 2))
+            self.assertEqual(frame["observation"]["image_main"].shape, (2,))
+            self.assertEqual(frame["observation"]["timestep_pad_mask"].shape, (2,))
+            self.assertEqual(frame["observation"]["task_completed"].shape, (2, 2))
+            self.assertEqual(frame["dataset_name"], "toy")
+
+        stats = result.statistics
+        self.assertEqual(stats.num_trajectories, 2)
+        self.assertEqual(stats.action.mean.shape, (2,))
+
+    def test_interleaved_dataset_sampling(self):
+        config_a = _make_config(
+            "dataset_a",
+            trajectories=[_make_trajectory(2, language="alpha")],
+            tmp_path=self.tmp_path,
+        )
+        config_b = _make_config(
+            "dataset_b",
+            trajectories=[_make_trajectory(4, language="beta", offset=0.7)],
+            tmp_path=self.tmp_path,
+        )
+
+        result = make_interleaved_dataset(
+            [config_a, config_b],
+            train=False,
+            sample_weights=[0.8, 0.2],
+            shuffle_buffer_size=3,
+        )
+
+        frames = list(itertools.islice(result.dataset, 6))
+        names = {frame["dataset_name"] for frame in frames}
+        self.assertTrue(names.issubset({"dataset_a", "dataset_b"}))
+        self.assertEqual(set(result.statistics.keys()), {"dataset_a", "dataset_b"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crossformer/data/grain/threading.py
+++ b/crossformer/data/grain/threading.py
@@ -1,0 +1,40 @@
+"""Helpers for configuring Google Grain threading and multiprocessing."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import grain.python as gp
+
+
+def create_read_options(
+    *,
+    num_threads: Optional[int] = None,
+    prefetch_buffer_size: Optional[int] = None,
+) -> gp.ReadOptions:
+    """Constructs :class:`grain.python.ReadOptions` with partial overrides."""
+
+    options = gp.ReadOptions()
+    if num_threads is not None:
+        options.num_threads = int(num_threads)
+    if prefetch_buffer_size is not None:
+        options.prefetch_buffer_size = int(prefetch_buffer_size)
+    return options
+
+
+def create_multiprocessing_options(
+    *,
+    num_workers: Optional[int] = None,
+    per_worker_buffer_size: Optional[int] = None,
+    enable_profiling: bool = False,
+) -> gp.MultiprocessingOptions:
+    """Creates :class:`grain.python.MultiprocessingOptions` with overrides."""
+
+    options = gp.MultiprocessingOptions()
+    if num_workers is not None:
+        options.num_workers = int(num_workers)
+    if per_worker_buffer_size is not None:
+        options.per_worker_buffer_size = int(per_worker_buffer_size)
+    options.enable_profiling = enable_profiling
+    return options
+

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -1,0 +1,282 @@
+"""Trajectory and frame level transforms implemented for Google Grain.
+
+The original TensorFlow pipeline exposes a fairly rich set of transforms that
+operate on either complete trajectories or on frame level chunks.  Rewriting
+every single transform for NumPy/JAX would be unnecessary for the initial
+Grain migration, however the core operations – chunking, padding, head masks,
+and simple subsampling – are required for parity.  This module provides these
+rewritten utilities in a framework agnostic way.
+
+All functions operate purely on nested dictionaries containing NumPy arrays or
+values that are trivially convertible to NumPy arrays.  They are therefore
+compatible with both ``grain.MapDataset`` and ``grain.IterDataset`` pipelines
+without introducing TensorFlow as a dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Iterable, Optional, Sequence
+
+import numpy as np
+
+from crossformer.data.grain import utils
+
+
+ArrayDict = dict[str, Any]
+Trajectory = dict[str, Any]
+
+
+def _ensure_array(value: Any) -> np.ndarray:
+    return utils.ensure_numpy(value)
+
+
+def _copy_traj(traj: Trajectory) -> Trajectory:
+    return utils.clone_structure(traj)
+
+
+def add_pad_mask_dict(traj: Trajectory) -> Trajectory:
+    """Annotates ``traj`` with padding masks for observation/task dictionaries."""
+
+    traj = _copy_traj(traj)
+    pad_masks = utils.tree_map(utils.is_padding, traj)
+    observation_masks = pad_masks.get("observation", {})
+    task_masks = pad_masks.get("task", {})
+    traj.setdefault("observation", {})
+    traj.setdefault("task", {})
+    traj["observation"]["pad_mask_dict"] = observation_masks
+    traj["task"]["pad_mask_dict"] = task_masks
+    return traj
+
+
+def add_head_action_mask(
+    traj: Trajectory, head_to_dataset: Mapping[str, Sequence[str]] | None = None
+) -> Trajectory:
+    """Adds per-head action masks mirroring TensorFlow implementation."""
+
+    traj = _copy_traj(traj)
+    dataset_names = traj.get("dataset_name")
+    if dataset_names is None:
+        raise KeyError("Expected 'dataset_name' field when adding head masks.")
+    dataset_names = np.asarray(dataset_names)
+    if head_to_dataset is None:
+        traj["action_head_masks"] = {
+            "action": np.ones_like(dataset_names, dtype=bool)
+        }
+        return traj
+
+    action_masks = {}
+    for head, dataset_list in head_to_dataset.items():
+        dataset_array = np.asarray(dataset_list, dtype=dataset_names.dtype)
+        mask = np.isin(dataset_names, dataset_array)
+        action_masks[head] = mask
+    traj["action_head_masks"] = action_masks
+    return traj
+
+
+def pad_actions_and_proprio(
+    traj: Trajectory,
+    *,
+    max_action_dim: int | None,
+    max_proprio_dim: int | None,
+) -> Trajectory:
+    """Pads actions/proprio streams and records action padding mask."""
+
+    traj = _copy_traj(traj)
+    actions = _ensure_array(traj["action"])
+    traj["action_pad_mask"] = np.ones_like(actions, dtype=bool)
+
+    if max_action_dim is not None:
+        action_dim = actions.shape[-1]
+        if action_dim > max_action_dim:
+            raise ValueError(
+                f"action_dim ({action_dim}) is greater than max_action_dim ({max_action_dim})"
+            )
+        pad_width = [(0, 0)] * (actions.ndim - 1) + [(0, max_action_dim - action_dim)]
+        traj["action"] = np.pad(actions, pad_width, mode="constant")
+        traj["action_pad_mask"] = np.pad(
+            traj["action_pad_mask"], pad_width, mode="constant", constant_values=False
+        )
+
+    if max_proprio_dim is not None and "proprio" in traj.get("observation", {}):
+        proprio = _ensure_array(traj["observation"]["proprio"])
+        proprio_dim = proprio.shape[-1]
+        if proprio_dim > max_proprio_dim:
+            raise ValueError(
+                f"proprio_dim ({proprio_dim}) is greater than max_proprio_dim ({max_proprio_dim})"
+            )
+        pad_width = [(0, 0), (0, max_proprio_dim - proprio_dim)]
+        traj["observation"]["proprio"] = np.pad(proprio, pad_width, mode="constant")
+
+    return traj
+
+
+def chunk_action_and_observation(
+    traj: Trajectory,
+    *,
+    window_size: int,
+    action_horizon: int,
+    override_window_size: Optional[int] = None,
+) -> Trajectory:
+    """Chunks observations into histories and actions into windows."""
+
+    traj = _copy_traj(traj)
+    actions = _ensure_array(traj["action"])
+    traj_len = actions.shape[0]
+
+    history_indices = (
+        np.arange(traj_len)[:, None] + np.arange(-window_size + 1, 1)[None, :]
+    )
+    timestep_pad_mask = history_indices >= 0
+    if override_window_size is not None:
+        valid_history = np.arange(window_size) >= window_size - override_window_size
+        timestep_pad_mask = np.logical_and(timestep_pad_mask, valid_history)
+    history_indices = np.maximum(history_indices, 0)
+
+    chunked_obs = {}
+    for key, value in traj["observation"].items():
+        if key == "pad_mask_dict":
+            chunked_obs[key] = value
+            continue
+        value = _ensure_array(value)
+        chunked_obs[key] = value[history_indices]
+    chunked_obs["timestep_pad_mask"] = timestep_pad_mask
+    traj["observation"] = chunked_obs
+
+    if actions.ndim == 2:
+        action_indices = (
+            np.arange(traj_len)[:, None] + np.arange(action_horizon)[None, :]
+        )
+        action_indices = np.minimum(action_indices, traj_len - 1)
+        actions = actions[action_indices]
+    else:
+        if actions.shape[1] < action_horizon:
+            raise ValueError(
+                "Pre-chunked action does not have enough horizon to satisfy"
+                f" requested action_horizon={action_horizon}."
+            )
+        actions = actions[:, :action_horizon]
+
+    actions = actions[history_indices]
+    traj["action"] = actions
+
+    if "task" not in traj:
+        traj["task"] = {}
+    task = traj["task"]
+    goal_timestep = task.get("timestep")
+    if goal_timestep is None:
+        goal_timestep = np.full((traj_len,), traj_len - 1, dtype=np.int32)
+    else:
+        goal_timestep = _ensure_array(goal_timestep)
+
+    t, w, h = np.meshgrid(
+        np.arange(traj_len), np.arange(window_size), np.arange(action_horizon), indexing="ij"
+    )
+    relative_goal = goal_timestep[:, None, None] - (t - (window_size + 1) + w + h)
+    traj["observation"]["task_completed"] = relative_goal <= 0
+
+    action_pad_mask = traj.get("action_pad_mask")
+    if action_pad_mask is None:
+        action_pad_mask = np.ones((*actions.shape[:-1], actions.shape[-1]), dtype=bool)
+    else:
+        action_pad_mask = _ensure_array(action_pad_mask)
+        if action_pad_mask.ndim == 2:
+            action_pad_mask = action_pad_mask[:, None, None, :]
+        elif action_pad_mask.ndim == 3:
+            action_pad_mask = action_pad_mask[:, None, :, :]
+    traj["action_pad_mask"] = np.logical_and(
+        action_pad_mask,
+        ~traj["observation"]["task_completed"][:, :, :, None],
+    )
+
+    return traj
+
+
+def subsample(traj: Trajectory, *, length: int, rng: np.random.Generator) -> Trajectory:
+    traj = _copy_traj(traj)
+    traj_len = traj["action"].shape[0]
+    if traj_len <= length:
+        return traj
+    indices = rng.choice(traj_len, size=length, replace=False)
+    indices.sort()
+
+    def gather(value: Any):
+        if isinstance(value, dict):
+            return {key: gather(sub_value) for key, sub_value in value.items()}
+        value = _ensure_array(value)
+        return value[indices]
+
+    for key in ("action", "observation", "task"):
+        if key in traj:
+            traj[key] = gather(traj[key])
+    return traj
+
+
+def zero_out_future_proprio(traj: Trajectory) -> Trajectory:
+    traj = _copy_traj(traj)
+    proprio = traj["observation"].get("proprio")
+    if proprio is None:
+        return traj
+    proprio = _ensure_array(proprio)
+    if proprio.ndim < 2:
+        raise ValueError("Expected proprio to be at least 2D after chunking.")
+    proprio[:, 1:] = 0
+    traj["observation"]["proprio"] = proprio
+    return traj
+
+
+def flatten_trajectory(traj: Trajectory) -> Iterable[dict[str, Any]]:
+    """Converts a chunked trajectory into a sequence of frame dictionaries."""
+
+    traj_len = traj["action"].shape[0]
+    for idx in range(traj_len):
+        frame = {
+            "observation": utils.tree_map(lambda x: _ensure_array(x)[idx], traj["observation"]),
+            "task": utils.tree_map(lambda x: _ensure_array(x)[idx], traj.get("task", {})),
+            "action": _ensure_array(traj["action"])[idx],
+            "action_pad_mask": _ensure_array(traj["action_pad_mask"])[idx],
+            "dataset_name": traj["dataset_name"][idx]
+            if isinstance(traj.get("dataset_name"), (np.ndarray, list))
+            else traj.get("dataset_name"),
+        }
+        if "action_head_masks" in traj:
+            frame["action_head_masks"] = {
+                head: np.asarray(mask)[idx]
+                for head, mask in traj["action_head_masks"].items()
+            }
+        yield frame
+
+
+def drop_empty_language(traj: Trajectory) -> Trajectory:
+    traj = _copy_traj(traj)
+    language = traj.get("task", {}).get("language_instruction")
+    if language is None:
+        return traj
+    language = np.asarray(language)
+    keep = language != ""
+    if np.all(~keep):
+        raise ValueError("Trajectory does not contain any language annotation.")
+    return traj
+
+
+def uniform_goal_relabel(traj: Trajectory, *, rng: np.random.Generator) -> Trajectory:
+    traj = _copy_traj(traj)
+    obs = traj["observation"]
+    traj_len = _ensure_array(traj["action"]).shape[0]
+    rand = rng.uniform(size=traj_len)
+    low = np.arange(traj_len)
+    high = np.full(traj_len, traj_len)
+    goal_indices = (rand * (high - low) + low).astype(int)
+    goal_indices = np.clip(goal_indices, 0, traj_len - 1)
+    goal = utils.tree_map(lambda x: _ensure_array(x)[goal_indices], obs)
+    traj.setdefault("task", {})
+    traj["task"] = utils.tree_merge(traj["task"], goal)
+    return traj
+
+
+def maybe_cast_dtype(value: Any, dtype: np.dtype | type[np.number]) -> np.ndarray:
+    array = _ensure_array(value)
+    if array.dtype != dtype:
+        array = array.astype(dtype)
+    return array
+

--- a/crossformer/data/grain/utils.py
+++ b/crossformer/data/grain/utils.py
@@ -1,0 +1,146 @@
+"""Utility helpers for the Grain data pipeline.
+
+The TensorFlow based pipeline under :mod:`crossformer.data.dataset` relies on
+TensorFlow primitives for a large collection of small utilities such as
+recursive tree mapping, padding helpers, or dictionary merges.  The Grain based
+pipeline needs the same functionality but implemented using NumPy/JAX friendly
+operations so that it remains completely framework agnostic.
+
+Only a very small subset of helpers are required for the initial Grain
+implementation and they are intentionally kept lightweight.  They operate on
+standard Python containers (``dict``/``list``) and NumPy/JAX arrays so they can
+be freely reused both inside tests and production code without pulling in
+TensorFlow as a dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+import copy
+from typing import Any
+
+import numpy as np
+
+
+Tree = Mapping[str, Any] | dict[str, Any]
+
+
+def tree_map(fn: Callable[[Any], Any], tree: Tree) -> Tree:
+    """Applies ``fn`` recursively to every leaf in ``tree``.
+
+    ``tree`` is expected to be made of nested ``dict`` instances.  Lists and
+    tuples are treated as leaves to avoid surprising conversions between data
+    structures.  This mirrors the behaviour of ``tf.nest.map_structure`` which
+    the TensorFlow pipeline relies on.
+    """
+
+    def _map(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {key: _map(sub_value) for key, sub_value in value.items()}
+        return fn(value)
+
+    return _map(tree)
+
+
+def tree_merge(*trees: Tree) -> Tree:
+    """Merges ``trees`` recursively with right-most values taking precedence."""
+
+    if not trees:
+        return {}
+    result: dict[str, Any] = {}
+    for tree in trees:
+        for key, value in tree.items():
+            if isinstance(value, dict) and isinstance(result.get(key), dict):
+                result[key] = tree_merge(result[key], value)  # type: ignore[arg-type]
+            elif isinstance(value, dict):
+                result[key] = tree_merge(value)
+            else:
+                result[key] = value
+    return result
+
+
+def clone_structure(value: Any) -> Any:
+    """Returns a deep copy of ``value`` preserving NumPy arrays.
+
+    ``copy.deepcopy`` would normally work but it has two undesirable
+    properties:
+
+    * it recursively copies NumPy arrays which is unnecessary and expensive
+      for large tensors;
+    * it is not guaranteed to work with objects backed by shared memory which
+      the Grain data sources may rely on.
+
+    This helper performs a deep copy for Python containers while keeping NumPy
+    arrays (and other objects that expose ``__array__``) as views.
+    """
+
+    if isinstance(value, dict):
+        return {key: clone_structure(sub_value) for key, sub_value in value.items()}
+    if isinstance(value, list):
+        return [clone_structure(sub_value) for sub_value in value]
+    if isinstance(value, tuple):
+        return tuple(clone_structure(sub_value) for sub_value in value)
+    if isinstance(value, np.ndarray):
+        return value.copy()
+    return copy.deepcopy(value)
+
+
+def is_padding(value: Any) -> np.ndarray:
+    """Returns a boolean mask indicating which entries correspond to padding.
+
+    The heuristic mirrors the TensorFlow implementation:
+
+    * numerical arrays are considered padding if every element is ``0``;
+    * byte/Unicode arrays are padding if they are empty strings;
+    * boolean arrays use ``False`` as the padding sentinel;
+    * nested dictionaries are processed recursively with logical ``and``.
+
+    The return type is always a boolean NumPy array matching the input shape.
+    """
+
+    if isinstance(value, dict):
+        masks = [is_padding(sub_value) for sub_value in value.values()]
+        if not masks:
+            raise ValueError("Cannot infer padding mask for empty dict.")
+        mask = masks[0]
+        for sub_mask in masks[1:]:
+            mask = np.logical_and(mask, sub_mask)
+        return mask
+    value = np.asarray(value)
+    if value.dtype.kind in {"U", "S"}:
+        return value == ""
+    if value.dtype == np.bool_:
+        return ~value
+    return value == 0
+
+
+def to_padding(value: Any) -> Any:
+    """Creates a padding value with the same shape/dtype as ``value``."""
+
+    value = np.asarray(value)
+    if value.dtype.kind in {"U", "S"}:
+        return np.zeros_like(value, dtype=value.dtype)
+    if value.dtype == np.bool_:
+        return np.zeros_like(value, dtype=bool)
+    return np.zeros_like(value)
+
+
+def ensure_numpy(value: Any) -> np.ndarray:
+    """Converts ``value`` to a NumPy array if possible."""
+
+    if isinstance(value, np.ndarray):
+        return value
+    if hasattr(value, "__array__"):
+        return np.asarray(value)
+    return np.array(value)
+
+
+def as_dict(data: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Returns ``data`` as a mutable dictionary."""
+
+    if data is None:
+        return {}
+    if isinstance(data, dict):
+        return data
+    return dict(data)
+


### PR DESCRIPTION
## Summary
- implement a new Google Grain data pipeline including builders, trajectory transforms, and frame flattening utilities
- add dataset statistics/normalization logic plus threading and sharding helpers for the Grain backend
- introduce unit tests that exercise the single-dataset and interleaved dataset flows using in-memory trajectories

## Testing
- `python -m unittest discover crossformer/data/grain/tests`


------
https://chatgpt.com/codex/tasks/task_e_68cf383f002083298e4267d20925f2af