### PR TITLE
Add comprehensive Flax component test coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,176 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+import jax  # noqa: E402
+from jax._src import config as jax_internal_config  # noqa: E402
+import types  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+
+# Flax expects newer JAX builds that expose define_bool_state; alias to the
+# modern equivalent when running tests on newer releases.
+if not hasattr(jax.config, "define_bool_state"):
+    jax.config.define_bool_state = jax_internal_config.bool_state
+
+# Recent JAX versions removed jax.experimental.maps, but Flax still imports it.
+if "jax.experimental.maps" not in sys.modules:
+    maps_module = types.ModuleType("jax.experimental.maps")
+    empty_mesh = types.SimpleNamespace(devices=types.SimpleNamespace(shape=()))
+    maps_module.thread_resources = types.SimpleNamespace(env=types.SimpleNamespace(physical_mesh=empty_mesh))
+    sys.modules["jax.experimental.maps"] = maps_module
+    if hasattr(jax, "experimental"):
+        setattr(jax.experimental, "maps", maps_module)
+
+if not hasattr(jax.nn, "normalize"):
+    def _normalize(x, axis=-1, epsilon=1e-12):
+        norm = jnp.linalg.norm(x, axis=axis, keepdims=True)
+        return x / (norm + epsilon)
+
+    jax.nn.normalize = _normalize
+
+if "tensorflow" not in sys.modules:
+    tf_module = types.ModuleType("tensorflow")
+
+    class _Tensor(np.ndarray):
+        def __new__(cls, input_array, tf_dtype=None):
+            obj = np.asarray(input_array).view(cls)
+            obj._tf_dtype = tf_dtype
+            return obj
+
+        @property
+        def dtype(self):
+            return getattr(self, "_tf_dtype", None) or super().dtype
+
+        def numpy(self):
+            return np.asarray(self)
+
+    def _to_tensor(value, dtype=None):
+        np_dtype = getattr(dtype, "as_numpy_dtype", dtype)
+        array = np.array(value, dtype=np_dtype) if dtype is not None else np.array(value)
+        return _Tensor(array, tf_dtype=dtype)
+
+    def _uniform(shape, minval=0.0, maxval=1.0, dtype=np.float32):
+        np_dtype = getattr(dtype, "as_numpy_dtype", dtype)
+        data = np.random.uniform(minval, maxval, size=shape).astype(np_dtype)
+        return _Tensor(data, tf_dtype=dtype)
+
+    def _range(start, limit=None, delta=1, dtype=np.int32):
+        if limit is None:
+            start, limit = 0, start
+        np_dtype = getattr(dtype, "as_numpy_dtype", dtype)
+        return _Tensor(np.arange(start, limit, delta, dtype=np_dtype), tf_dtype=dtype)
+
+    def _asarray(value):
+        return np.asarray(value)
+
+    def _tensor_from(value, dtype=None):
+        if dtype is None:
+            return _Tensor(np.asarray(value))
+        np_dtype = getattr(dtype, "as_numpy_dtype", dtype)
+        return _Tensor(np.asarray(value, dtype=np_dtype), tf_dtype=dtype)
+
+    tf_module.float32 = np.float32
+    tf_module.bool = np.bool_
+    tf_module.int32 = np.int32
+    tf_module.Tensor = _Tensor
+    tf_module.Variable = _Tensor
+    tf_module.string = np.bytes_
+
+    tf_module.random = types.SimpleNamespace(
+        uniform=_uniform,
+        shuffle=lambda x: _Tensor(
+            np.random.permutation(_asarray(x)),
+            tf_dtype=getattr(x, "dtype", None),
+        ),
+    )
+    tf_module.ones = lambda shape, dtype=np.float32: _tensor_from(
+        np.ones(shape, dtype=getattr(dtype, "as_numpy_dtype", dtype)), dtype
+    )
+    tf_module.ones_like = lambda value, dtype=None: _tensor_from(
+        np.ones_like(_asarray(value), dtype=getattr(dtype, "as_numpy_dtype", dtype)),
+        dtype,
+    )
+    tf_module.zeros_like = lambda value, dtype=None: _tensor_from(
+        np.zeros_like(_asarray(value), dtype=getattr(dtype, "as_numpy_dtype", dtype)),
+        dtype,
+    )
+    tf_module.zeros = lambda shape, dtype=np.float32: _tensor_from(
+        np.zeros(shape, dtype=getattr(dtype, "as_numpy_dtype", dtype)), dtype
+    )
+    tf_module.constant = lambda value, dtype=None: _to_tensor(value, dtype)
+    tf_module.shape = lambda value: np.shape(value)
+    tf_module.range = _range
+    def _dtype_of(*values, default=None):
+        for value in values:
+            if isinstance(value, _Tensor) and getattr(value, "_tf_dtype", None) is not None:
+                return value._tf_dtype
+        return default
+
+    tf_module.maximum = lambda x, y: _tensor_from(
+        np.maximum(_asarray(x), _asarray(y)), _dtype_of(x, y)
+    )
+    tf_module.minimum = lambda x, y: _tensor_from(
+        np.minimum(_asarray(x), _asarray(y)), _dtype_of(x, y)
+    )
+    tf_module.where = lambda cond, x, y: _tensor_from(
+        np.where(_asarray(cond), _asarray(x), _asarray(y)), _dtype_of(x, y)
+    )
+    tf_module.logical_and = lambda x, y: _tensor_from(
+        np.logical_and(_asarray(x), _asarray(y)), np.bool_
+    )
+    tf_module.logical_not = lambda x: _tensor_from(np.logical_not(_asarray(x)), np.bool_)
+    tf_module.fill = lambda dims, value: _tensor_from(
+        np.full(tuple(np.asarray(dims, dtype=int).tolist()), value), type(value)
+    )
+    tf_module.meshgrid = lambda *args, **kwargs: [
+        _Tensor(arr) for arr in np.meshgrid(*map(_asarray, args), **kwargs)
+    ]
+    tf_module.concat = lambda values, axis=0: _tensor_from(
+        np.concatenate([_asarray(v) for v in values], axis=axis),
+        _dtype_of(*values),
+    )
+    tf_module.pad = lambda tensor, paddings, mode="constant", constant_values=0: _tensor_from(
+        np.pad(
+            _asarray(tensor),
+            [tuple(p) for p in paddings],
+            mode=mode,
+            constant_values=constant_values,
+        ),
+        getattr(tensor, "dtype", None),
+    )
+    tf_module.gather = lambda params, indices, axis=0: _tensor_from(
+        np.take(_asarray(params), _asarray(indices), axis=axis), getattr(params, "dtype", None)
+    )
+    tf_module.map_fn = lambda fn, elems, fn_output_signature=None: _tensor_from(
+        np.array([fn(elem) for elem in _asarray(elems)]), fn_output_signature
+    )
+    tf_module.reduce_any = lambda value, axis=None: np.any(value, axis=axis)
+    tf_module.equal = lambda x, y: _tensor_from(
+        np.equal(_asarray(x), _asarray(y)), np.bool_
+    )
+    tf_module.reshape = lambda tensor, shape: _tensor_from(
+        np.reshape(_asarray(tensor), tuple(shape)), getattr(tensor, "dtype", None)
+    )
+    tf_module.cast = lambda value, dtype: _tensor_from(
+        _asarray(value).astype(getattr(dtype, "as_numpy_dtype", dtype)), dtype
+    )
+    def _string_length(value):
+        arr = _asarray(value)
+
+        def _len(elem):
+            if isinstance(elem, bytes) or isinstance(elem, np.bytes_):
+                return len(elem.decode("utf-8"))
+            return len(str(elem))
+
+        vectorized = np.vectorize(_len, otypes=[np.int32])
+        return _tensor_from(vectorized(arr), np.int32)
+
+    tf_module.strings = types.SimpleNamespace(length=_string_length)
+    tf_module.nest = types.SimpleNamespace(
+        map_structure=lambda func, *structures: jax.tree_util.tree_map(
+            lambda *xs: func(*xs), *structures
+        )
+    )
+
+    sys.modules["tensorflow"] = tf_module

--- a/tests/model/components/test_action_heads.py
+++ b/tests/model/components/test_action_heads.py
@@ -1,0 +1,138 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+from crossformer.model.components.action_heads import (
+    ContinuousActionHead,
+    DiffusionActionHead,
+    L1ActionHead,
+    MSEActionHead,
+    continuous_loss,
+)
+from crossformer.model.components.base import TokenGroup
+
+
+@pytest.fixture
+def transformer_outputs():
+    tokens = jnp.linspace(0, 1, 2 * 3 * 4 * 8).reshape(2, 3, 4, 8)
+    mask = jnp.ones((2, 3, 4))
+    return {"obs": TokenGroup(tokens=tokens, mask=mask)}
+
+
+def test_continuous_loss_mse_and_l1():
+    pred = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    target = jnp.array([[2.0, 2.0], [1.0, 6.0]])
+    mask = jnp.array([[1.0, 0.0], [1.0, 1.0]])
+
+    mse_loss, metrics = continuous_loss(pred, target, mask, loss_type="mse")
+    assert mse_loss == pytest.approx(3.0, rel=1e-5)
+    assert set(metrics.keys()) == {"loss", "mse", "lsign"}
+
+    l1_loss, _ = continuous_loss(pred, target, mask, loss_type="l1")
+    assert l1_loss < mse_loss
+
+
+@pytest.mark.parametrize("pool_strategy", ["mean", "pass"])
+def test_continuous_action_head_forward_and_loss(transformer_outputs, pool_strategy):
+    if pool_strategy == "pass":
+        tokens = transformer_outputs["obs"].tokens.reshape(2, 3, 2, 16)
+        mask = jnp.ones((2, 3, 2))
+        transformer_outputs = {"obs": TokenGroup(tokens=tokens, mask=mask)}
+
+    head = ContinuousActionHead(
+        readout_key="obs",
+        pool_strategy=pool_strategy,
+        action_horizon=2,
+        action_dim=3,
+    )
+
+    params = head.init(jax.random.PRNGKey(0), transformer_outputs, train=True)
+    preds = head.apply(params, transformer_outputs, train=True)
+
+    if pool_strategy == "pass":
+        expected_last_dim = head.num_preds or head.action_horizon * head.action_dim
+        assert preds.shape == (2, 3, head.action_horizon, expected_last_dim)
+    else:
+        assert preds.shape == (2, 3, head.action_horizon, head.action_dim)
+    assert jnp.all(jnp.abs(preds) <= head.max_action + 1e-5)
+
+    actions = jnp.zeros_like(preds)
+    timestep_mask = jnp.ones((2, 3), dtype=bool)
+    action_pad_mask = jnp.ones_like(preds, dtype=bool)
+
+    if pool_strategy != "pass":
+        loss, metrics = head.apply(
+            params,
+            transformer_outputs,
+            actions,
+            timestep_mask,
+            action_pad_mask,
+            method=head.loss,
+        )
+        assert loss.shape == ()
+        assert metrics["loss"].shape == ()
+
+
+def test_l1_action_head_inherits_loss_type():
+    head = L1ActionHead(readout_key="obs")
+    assert head.loss_type == "l1"
+
+
+def test_mse_action_head_uses_map_head(transformer_outputs):
+    head = MSEActionHead(readout_key="obs", action_horizon=1, action_dim=2)
+    params = head.init(jax.random.PRNGKey(0), transformer_outputs, train=False)
+    preds = head.apply(params, transformer_outputs, train=False)
+    assert preds.shape == (2, 3, 1, 2)
+
+
+def test_diffusion_action_head_forward_loss_and_sampling(transformer_outputs):
+    head = DiffusionActionHead(
+        readout_key="obs",
+        action_horizon=1,
+        action_dim=2,
+        time_dim=8,
+        num_blocks=1,
+        hidden_dim=16,
+        diffusion_steps=4,
+        dropout_rate=0.0,
+    )
+
+    params = head.init(jax.random.PRNGKey(1), transformer_outputs, train=True)
+
+    dummy_time = jnp.zeros((2, 3, 1), dtype=jnp.int32)
+    dummy_noisy = jnp.zeros((2, 3, 2), dtype=jnp.float32)
+    output = head.apply(
+        params,
+        transformer_outputs,
+        dummy_time,
+        dummy_noisy,
+        train=False,
+    )
+    assert output.shape == (2, 3, 2)
+
+    actions = jnp.zeros((2, 3, 1, 2))
+    timestep_mask = jnp.ones((2, 3), dtype=bool)
+    action_pad_mask = jnp.ones_like(actions, dtype=bool)
+
+    loss, metrics = head.apply(
+        params,
+        transformer_outputs,
+        actions,
+        timestep_mask,
+        action_pad_mask,
+        method=head.loss,
+        rngs={"dropout": jax.random.PRNGKey(2)},
+    )
+
+    assert loss.shape == ()
+    assert "mse" in metrics
+
+    sampled = head.apply(
+        params,
+        transformer_outputs,
+        rng=jax.random.PRNGKey(3),
+        sample_shape=(2,),
+        method=head.predict_action,
+    )
+
+    assert sampled.shape == (2, 2, 3, 1, 2)

--- a/tests/model/components/test_base.py
+++ b/tests/model/components/test_base.py
@@ -1,0 +1,25 @@
+import jax.numpy as jnp
+
+from crossformer.model.components.base import TokenGroup
+
+
+def test_token_group_create_default_mask():
+    tokens = jnp.ones((2, 3, 4))
+    group = TokenGroup.create(tokens)
+
+    assert group.tokens.shape == (2, 3, 4)
+    assert group.mask.shape == (2, 3)
+    assert jnp.all(group.mask == 1)
+
+
+def test_token_group_concatenate():
+    g1 = TokenGroup.create(jnp.zeros((1, 2, 4)), jnp.array([[1, 0]]))
+    g2 = TokenGroup.create(jnp.ones((1, 3, 4)), jnp.array([[1, 1, 0]]))
+
+    combined = TokenGroup.concatenate([g1, g2])
+
+    assert combined.tokens.shape == (1, 5, 4)
+    assert combined.mask.shape == (1, 5)
+    assert jnp.allclose(combined.tokens[:, :2], 0)
+    assert jnp.allclose(combined.tokens[:, 2:], 1)
+    assert jnp.array_equal(combined.mask, jnp.array([[1, 0, 1, 1, 0]]))

--- a/tests/model/components/test_block_transformer.py
+++ b/tests/model/components/test_block_transformer.py
@@ -1,0 +1,130 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from crossformer.model.components.block_transformer import (
+    AttentionRule,
+    BlockTransformer,
+    PrefixGroup,
+    TimestepGroup,
+    TokenMetadata,
+)
+
+
+def _make_groups(batch_size=2, horizon=3, embed_dim=8):
+    prefix_tokens = jnp.ones((batch_size, 1, embed_dim))
+    prefix_pos = jnp.zeros_like(prefix_tokens)
+    prefix_mask = jnp.ones((batch_size, 1), dtype=jnp.bool_)
+    prefix_group = PrefixGroup(
+        tokens=prefix_tokens,
+        mask=prefix_mask,
+        pos_enc=prefix_pos,
+        name="task",
+        attention_rules={"task": AttentionRule.CAUSAL},
+    )
+
+    timestep_tokens = jnp.ones((batch_size, horizon, 2, embed_dim))
+    timestep_pos = jnp.zeros_like(timestep_tokens)
+    timestep_mask = jnp.ones((batch_size, horizon, 2), dtype=jnp.bool_)
+    timestep_group = TimestepGroup(
+        tokens=timestep_tokens,
+        mask=timestep_mask,
+        pos_enc=timestep_pos,
+        name="obs",
+        attention_rules={"task": AttentionRule.CAUSAL, "obs": AttentionRule.CAUSAL},
+    )
+    return [prefix_group], [timestep_group]
+
+
+def test_token_metadata_rules():
+    prefix_groups, timestep_groups = _make_groups(batch_size=1, horizon=2, embed_dim=4)
+    prefix_meta = TokenMetadata.create(prefix_groups[0], timestep=-1)
+    timestep_meta_now = TokenMetadata.create(timestep_groups[0], timestep=1)
+    timestep_meta_past = TokenMetadata.create(timestep_groups[0], timestep=0)
+
+    assert prefix_meta.should_attend_to(prefix_meta) is True
+    assert prefix_meta.should_attend_to(timestep_meta_now) is False
+    assert timestep_meta_now.should_attend_to(prefix_meta) is True
+    assert timestep_meta_now.should_attend_to(timestep_meta_past) is True
+    assert timestep_meta_past.should_attend_to(timestep_meta_now) is False
+
+
+def test_block_transformer_call_and_split_roundtrip():
+    prefix_groups, timestep_groups = _make_groups()
+    block = BlockTransformer(
+        transformer_kwargs=dict(
+            num_layers=1,
+            mlp_dim=16,
+            num_attention_heads=2,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            repeat_pos_enc=False,
+        )
+    )
+
+    params = block.init(jax.random.PRNGKey(0), prefix_groups, timestep_groups, train=False)
+    prefix_out, timestep_out = block.apply(
+        params, prefix_groups, timestep_groups, train=False
+    )
+
+    assert len(prefix_out) == 1 and len(timestep_out) == 1
+    assert prefix_out[0].tokens.shape == prefix_groups[0].tokens.shape
+    assert timestep_out[0].tokens.shape == timestep_groups[0].tokens.shape
+
+    tokens, pos = block.assemble_input_tokens(prefix_groups, timestep_groups)
+    rebuilt_prefix, rebuilt_timestep = block.split_output_tokens(
+        tokens, prefix_groups, timestep_groups
+    )
+    np.testing.assert_allclose(rebuilt_prefix[0].tokens, prefix_groups[0].tokens)
+    np.testing.assert_allclose(
+        rebuilt_timestep[0].tokens, timestep_groups[0].tokens
+    )
+
+
+def test_attention_mask_generation():
+    prefix_groups, timestep_groups = _make_groups(batch_size=1, horizon=2, embed_dim=4)
+    block = BlockTransformer(transformer_kwargs=dict(num_layers=1, mlp_dim=8, num_attention_heads=2))
+    mask = block.generate_attention_mask(prefix_groups, timestep_groups)
+
+    assert mask.shape == (1, 1, 5, 5)
+
+    # Expected pattern: prefix attends to prefix, timestep tokens attend to prefix and causal past.
+    expected = np.array(
+        [
+            [1, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0],
+            [1, 1, 1, 0, 0],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1],
+        ],
+        dtype=bool,
+    )
+    np.testing.assert_array_equal(mask[0, 0], expected)
+
+
+def test_generate_pad_attention_mask_respects_padding():
+    prefix_groups, timestep_groups = _make_groups(batch_size=1, horizon=2, embed_dim=2)
+    timestep_groups[0] = timestep_groups[0].replace(
+        mask=jnp.array([[[True, False], [True, True]]])
+    )
+
+    block = BlockTransformer(transformer_kwargs=dict(num_layers=1, mlp_dim=8, num_attention_heads=2))
+    generated = block.generate_pad_attention_mask(prefix_groups, timestep_groups)
+
+    assert generated.shape == (1, 1, 5, 5)
+    pad_vector = jnp.concatenate(
+        [prefix_groups[0].mask, timestep_groups[0].mask.reshape(1, -1)], axis=1
+    )
+    expected = jnp.broadcast_to(pad_vector[:, None, :], (1, 5, 5))[0]
+    np.testing.assert_array_equal(generated[0, 0], expected)
+
+
+def test_verify_causality_raises_for_future_attention():
+    prefix_groups, timestep_groups = _make_groups(batch_size=1, horizon=1)
+    timestep_groups[0] = timestep_groups[0].replace(
+        attention_rules={"task": AttentionRule.ALL, "obs": AttentionRule.ALL}
+    )
+    block = BlockTransformer(transformer_kwargs=dict(num_layers=1, mlp_dim=8, num_attention_heads=2))
+
+    with pytest.raises(AssertionError):
+        block.verify_causality(prefix_groups, timestep_groups)

--- a/tests/model/components/test_diffusion.py
+++ b/tests/model/components/test_diffusion.py
@@ -1,0 +1,120 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from crossformer.model.components.diffusion import (
+    FourierFeatures,
+    MLP,
+    MLPResNet,
+    MLPResNetBlock,
+    ScoreActor,
+    cosine_beta_schedule,
+    create_diffusion_model,
+)
+
+
+def test_cosine_beta_schedule_properties():
+    betas = cosine_beta_schedule(10)
+    assert betas.shape == (10,)
+    assert jnp.all((betas > 0) & (betas < 1))
+    assert jnp.all(betas[1:] >= betas[:-1] - 1e-6)
+
+
+def test_fourier_features_learnable_and_fixed():
+    inputs = jnp.ones((2, 1))
+    learnable = FourierFeatures(output_size=4, learnable=True)
+    params = learnable.init(jax.random.PRNGKey(0), inputs)
+    outputs = learnable.apply(params, inputs)
+    assert outputs.shape == (2, 4)
+
+    fixed = FourierFeatures(output_size=6, learnable=False)
+    params_fixed = fixed.init(jax.random.PRNGKey(1), inputs)
+    outputs_fixed = fixed.apply(params_fixed, inputs)
+    assert outputs_fixed.shape == (2, 6)
+    np.testing.assert_allclose(outputs_fixed[0, :3], outputs_fixed[1, :3])
+
+
+def test_mlp_and_resnet_blocks():
+    mlp = MLP((8, 4), use_layer_norm=True, dropout_rate=0.1, activate_final=True)
+    variables = mlp.init(
+        {"params": jax.random.PRNGKey(2), "dropout": jax.random.PRNGKey(3)},
+        jnp.ones((3, 2)),
+        train=True,
+    )
+    mlp_out = mlp.apply(
+        variables,
+        jnp.ones((3, 2)),
+        train=True,
+        rngs={"dropout": jax.random.PRNGKey(4)},
+    )
+    assert mlp_out.shape == (3, 4)
+
+    block = MLPResNetBlock(features=4, act=jax.nn.relu, dropout_rate=0.1, use_layer_norm=True)
+    block_vars = block.init(
+        {"params": jax.random.PRNGKey(5), "dropout": jax.random.PRNGKey(6)},
+        jnp.ones((3, 4)),
+        train=True,
+    )
+    block_out = block.apply(
+        block_vars,
+        jnp.ones((3, 4)),
+        train=True,
+        rngs={"dropout": jax.random.PRNGKey(7)},
+    )
+    assert block_out.shape == (3, 4)
+
+
+def test_mlp_resnet_stack():
+    resnet = MLPResNet(num_blocks=2, out_dim=5, hidden_dim=16, dropout_rate=0.0, use_layer_norm=True)
+    vars_resnet = resnet.init(jax.random.PRNGKey(6), jnp.ones((2, 4)), train=False)
+    out = resnet.apply(vars_resnet, jnp.ones((2, 4)), train=False)
+    assert out.shape == (2, 5)
+
+
+def test_score_actor_composition():
+    module = ScoreActor(
+        time_preprocess=FourierFeatures(output_size=4),
+        cond_encoder=MLP((8, 4)),
+        reverse_network=MLPResNet(num_blocks=1, out_dim=3, hidden_dim=8),
+    )
+    variables = module.init(
+        jax.random.PRNGKey(7),
+        obs_enc=jnp.ones((2, 3)),
+        actions=jnp.ones((2, 3)),
+        time=jnp.ones((2, 1)),
+        train=False,
+    )
+    out = module.apply(
+        variables,
+        obs_enc=jnp.ones((2, 3)),
+        actions=jnp.ones((2, 3)),
+        time=jnp.ones((2, 1)),
+        train=True,
+    )
+    assert out.shape == (2, 3)
+
+
+def test_create_diffusion_model_pipeline():
+    model = create_diffusion_model(
+        out_dim=4,
+        time_dim=4,
+        num_blocks=1,
+        dropout_rate=0.0,
+        hidden_dim=8,
+        use_layer_norm=True,
+    )
+    variables = model.init(
+        jax.random.PRNGKey(8),
+        obs_enc=jnp.ones((2, 4)),
+        actions=jnp.ones((2, 4)),
+        time=jnp.ones((2, 1)),
+        train=False,
+    )
+    outputs = model.apply(
+        variables,
+        obs_enc=jnp.ones((2, 4)),
+        actions=jnp.ones((2, 4)),
+        time=jnp.ones((2, 1)),
+        train=True,
+    )
+    assert outputs.shape == (2, 4)

--- a/tests/model/components/test_film_conditioning_layer.py
+++ b/tests/model/components/test_film_conditioning_layer.py
@@ -1,0 +1,17 @@
+import jax
+import jax.numpy as jnp
+
+from crossformer.model.components.film_conditioning_layer import FilmConditioning
+
+
+def test_film_conditioning_applies_shift_and_scale():
+    conv = jnp.ones((2, 4, 4, 3))
+    conditioning = jnp.array([[1.0, -1.0], [-0.5, 0.5]])
+    module = FilmConditioning()
+    variables = module.init(jax.random.PRNGKey(0), conv, conditioning)
+
+    output = module.apply(variables, conv, conditioning)
+    assert output.shape == conv.shape
+
+    zero_cond = module.apply(variables, conv, jnp.zeros_like(conditioning))
+    assert jnp.allclose(zero_cond, conv)

--- a/tests/model/components/test_tokenizers.py
+++ b/tests/model/components/test_tokenizers.py
@@ -1,0 +1,148 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from crossformer.model.components.base import TokenGroup
+from crossformer.model.components.tokenizers import (
+    BinTokenizer,
+    ImageTokenizer,
+    LanguageTokenizer,
+    LowdimObsTokenizer,
+    TokenLearner,
+    generate_proper_pad_mask,
+    regex_filter,
+    regex_match,
+)
+from crossformer.model.components.vit_encoders import PatchEncoder
+from crossformer.utils.spec import ModuleSpec
+
+
+def test_generate_proper_pad_mask_combines_sources():
+    tokens = jnp.zeros((2, 3, 4, 2))
+    pad_mask_dict = {
+        "a": jnp.array([[True, False, True], [False, True, True]]),
+        "b": jnp.array([[False, False, False], [False, False, False]]),
+    }
+    mask = generate_proper_pad_mask(tokens, pad_mask_dict, ("a", "b"))
+    expected = jnp.array(
+        [
+            [[True], [False], [True]],
+            [[False], [True], [True]],
+        ]
+    )
+    expected = jnp.broadcast_to(expected, tokens.shape[:-1])
+    np.testing.assert_array_equal(mask, expected)
+
+
+def test_token_learner_reduces_token_count():
+    module = TokenLearner(num_tokens=2)
+    inputs = jnp.ones((1, 4, 8))
+    variables = module.init(
+        {"params": jax.random.PRNGKey(0), "dropout": jax.random.PRNGKey(1)},
+        inputs,
+        train=True,
+    )
+    outputs = module.apply(variables, inputs, train=False)
+    assert outputs.shape == (1, module.num_tokens, inputs.shape[-1])
+
+
+@pytest.mark.parametrize("pattern, value", [("image_.*", True), ("depth_.*", False)])
+def test_regex_helpers(pattern, value):
+    keys = ["image_primary", "language_instruction"]
+    assert regex_match((pattern,), keys[0]) is value
+    filtered = regex_filter((pattern,), keys)
+    if value:
+        assert filtered == [keys[0]]
+    else:
+        assert filtered == []
+
+
+def _make_image_tokenizer(**overrides):
+    spec = ModuleSpec.create(PatchEncoder, patch_size=1, num_features=8)
+    return ImageTokenizer(encoder=spec, **overrides)
+
+
+def test_image_tokenizer_produces_token_group():
+    tokenizer = _make_image_tokenizer()
+    observations = {
+        "image_primary": jnp.ones((2, 2, 2, 2, 3)),
+        "pad_mask_dict": {"image_primary": jnp.array([[True, False], [True, True]])},
+    }
+    tasks = {}
+
+    variables = tokenizer.init(
+        {"params": jax.random.PRNGKey(0), "dropout": jax.random.PRNGKey(1)},
+        observations,
+        tasks,
+        train=False,
+    )
+    group = tokenizer.apply(variables, observations, tasks, train=False)
+    assert isinstance(group, TokenGroup)
+    assert group.tokens.shape[0:2] == (2, 2)
+    assert group.mask.shape == (2, 2, group.tokens.shape[2])
+
+
+def test_image_tokenizer_with_token_learner():
+    tokenizer = _make_image_tokenizer(use_token_learner=True, num_tokens=3)
+    observations = {
+        "image_primary": jnp.ones((1, 2, 2, 2, 3)),
+        "pad_mask_dict": {"image_primary": jnp.array([[True, True]])},
+    }
+    tasks = {}
+    variables = tokenizer.init(
+        {"params": jax.random.PRNGKey(2), "dropout": jax.random.PRNGKey(3)},
+        observations,
+        tasks,
+        train=True,
+    )
+    group = tokenizer.apply(
+        variables,
+        observations,
+        tasks,
+        train=True,
+        rngs={"dropout": jax.random.PRNGKey(4)},
+    )
+    assert group.tokens.shape == (1, 2, 3, group.tokens.shape[-1])
+
+
+def test_language_tokenizer_uses_pad_mask():
+    tokenizer = LanguageTokenizer(proper_pad_mask=True)
+    tasks = {
+        "language_instruction": jnp.array([[[[1]], [[2]], [[3]]]]),
+        "pad_mask_dict": {"language_instruction": jnp.array([[True, True, False]])},
+    }
+    observations = {}
+    group = tokenizer(observations, tasks, train=False)
+    assert isinstance(group, TokenGroup)
+    assert group.tokens.shape == (1, 3, 1, 1)
+    np.testing.assert_array_equal(group.mask, jnp.array([[[True], [True], [False]]]))
+
+
+def test_bin_tokenizer_encode_and_decode():
+    tokenizer = BinTokenizer(n_bins=4, bin_type="uniform", low=0.0, high=1.0)
+    inputs = jnp.array([[0.1, 0.5, 0.9]])
+    variables = tokenizer.init(jax.random.PRNGKey(5), inputs)
+    tokens = tokenizer.apply(variables, inputs)
+    assert jnp.issubdtype(tokens.dtype, jnp.integer)
+    decoded = tokenizer.apply(variables, tokens, method=tokenizer.decode)
+    assert decoded.shape == inputs.shape
+
+
+def test_lowdim_obs_tokenizer_continuous_and_discrete():
+    observations = {"state": jnp.ones((1, 2, 3))}
+    tasks = {}
+    tokenizer = LowdimObsTokenizer(obs_keys=("state",), discretize=False)
+    variables = tokenizer.init({"params": jax.random.PRNGKey(6)}, observations, tasks, train=False)
+    group = tokenizer.apply(variables, observations, tasks, train=False)
+    assert group.tokens.shape == (1, 2, 3, 1)
+
+    tokenizer_discrete = LowdimObsTokenizer(
+        obs_keys=("state",), discretize=True, n_bins=8
+    )
+    variables_disc = tokenizer_discrete.init(
+        {"params": jax.random.PRNGKey(7)}, observations, tasks, train=False
+    )
+    group_disc = tokenizer_discrete.apply(variables_disc, observations, tasks, train=False)
+    assert group_disc.tokens.shape == (1, 2, 3, 8)
+    assert jnp.all((group_disc.tokens.sum(axis=-1) == 1))

--- a/tests/model/components/test_transformer.py
+++ b/tests/model/components/test_transformer.py
@@ -1,0 +1,88 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from crossformer.model.components.base import TokenGroup
+from crossformer.model.components.transformer import (
+    AddPositionEmbs,
+    Encoder1DBlock,
+    MAPHead,
+    MlpBlock,
+    Transformer,
+    common_transformer_sizes,
+)
+
+
+def test_add_position_embs_adds_bias():
+    module = AddPositionEmbs(
+        posemb_init=lambda key, shape, dtype=jnp.float32: jnp.ones(shape, dtype)
+    )
+    inputs = jnp.zeros((2, 3, 4))
+    variables = module.init(jax.random.PRNGKey(0), inputs)
+    outputs = module.apply(variables, inputs)
+    np.testing.assert_array_equal(outputs, jnp.ones_like(inputs))
+
+
+def test_mlp_block_output_shape():
+    block = MlpBlock(mlp_dim=8, dropout_rate=0.0)
+    variables = block.init(jax.random.PRNGKey(1), jnp.ones((2, 4)), deterministic=True)
+    outputs = block.apply(variables, jnp.ones((2, 4)), deterministic=True)
+    assert outputs.shape == (2, 4)
+
+
+def test_map_head_with_token_group_and_array():
+    tokens = jnp.ones((2, 5, 6))
+    mask = jnp.array([[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]])
+    group = TokenGroup(tokens=tokens, mask=mask)
+
+    head = MAPHead(num_heads=2, num_readouts=2)
+    variables = head.init(jax.random.PRNGKey(2), group, train=False)
+    out_group = head.apply(variables, group, train=False)
+    assert out_group.shape == (2, 2, 6)
+
+    out_array = head.apply(variables, tokens, train=False)
+    assert out_array.shape == (2, head.num_readouts, tokens.shape[-1])
+
+
+def test_encoder_block_respects_mask_and_positional_encoding():
+    block = Encoder1DBlock(
+        mlp_dim=8,
+        num_heads=2,
+        dropout_rate=0.0,
+        attention_dropout_rate=0.0,
+        repeat_pos_enc=True,
+    )
+    x = jnp.ones((2, 4, 6))
+    pos_enc = jnp.linspace(0, 1, 2 * 4 * 6).reshape(2, 4, 6)
+    attn_mask = jnp.ones((2, 1, 4, 4))
+    variables = block.init(jax.random.PRNGKey(3), x, pos_enc, attn_mask, deterministic=True)
+    out = block.apply(variables, x, pos_enc, attn_mask, deterministic=True)
+    assert out.shape == x.shape
+
+
+def test_transformer_encoder_stack():
+    transformer = Transformer(
+        num_layers=2,
+        mlp_dim=16,
+        num_attention_heads=2,
+        dropout_rate=0.0,
+        attention_dropout_rate=0.0,
+        repeat_pos_enc=False,
+    )
+    x = jnp.ones((1, 4, 8))
+    pos_enc = jnp.zeros_like(x)
+    attn_mask = jnp.ones((1, 1, 4, 4))
+    variables = transformer.init(jax.random.PRNGKey(4), x, pos_enc, attn_mask, train=False)
+    out = transformer.apply(variables, x, pos_enc, attn_mask, train=False)
+    assert out.shape == x.shape
+
+
+def test_common_transformer_sizes_return_expected_values():
+    dim, config = common_transformer_sizes("vit_b")
+    assert dim == 768
+    assert config["num_layers"] == 12
+    assert config["num_attention_heads"] == 12
+
+    dim_dummy, config_dummy = common_transformer_sizes("dummy")
+    assert dim_dummy == 256
+    assert config_dummy["num_layers"] == 1

--- a/tests/model/components/test_vit_encoders.py
+++ b/tests/model/components/test_vit_encoders.py
@@ -1,0 +1,142 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from crossformer.model.components.vit_encoders import (
+    PatchEncoder,
+    ResNet26,
+    ResNet26FILM,
+    ResNetStage,
+    ResidualUnit,
+    SmallStem,
+    SmallStem16,
+    SmallStem32,
+    ViTResnet,
+    normalize_images,
+    vit_encoder_configs,
+    weight_standardize,
+)
+from crossformer.model.components.vit_encoders import StdConv
+from flax import linen as nn
+
+
+def test_normalize_images_default_and_imagenet():
+    default = normalize_images(jnp.array([[[[0], [255]]]], dtype=jnp.uint8))
+    assert default.min() >= -1.0 and default.max() <= 1.0
+
+    imagenet_input = jnp.ones((1, 2, 2, 6), dtype=jnp.uint8)
+    imagenet = normalize_images(imagenet_input, img_norm_type="imagenet")
+    assert imagenet.shape == imagenet_input.shape
+
+
+def test_weight_standardize_normalizes_kernel():
+    kernel = jnp.arange(3 * 3 * 2 * 4, dtype=jnp.float32).reshape(3, 3, 2, 4)
+    standardized = weight_standardize(kernel, axis=[0, 1, 2], eps=1e-5)
+    mean = standardized.mean(axis=(0, 1, 2))
+    std = standardized.std(axis=(0, 1, 2))
+    np.testing.assert_allclose(mean, jnp.zeros_like(mean), atol=1e-6)
+    np.testing.assert_allclose(std, jnp.ones_like(std), atol=1e-6)
+
+
+def test_stdconv_applies_weight_standardization():
+    conv = StdConv(features=2, kernel_size=(3, 3))
+    inputs = jnp.ones((1, 5, 5, 2))
+    variables = conv.init(jax.random.PRNGKey(0), inputs)
+    outputs = conv.apply(variables, inputs)
+
+    kernel = variables["params"]["kernel"]
+    standardized_kernel = weight_standardize(kernel, axis=[0, 1, 2], eps=1e-5)
+    ref_conv = nn.Conv(features=2, kernel_size=(3, 3))
+    params = dict(variables["params"])
+    ref_params = {
+        "params": {
+            "kernel": standardized_kernel,
+            "bias": params["bias"]
+            if "bias" in params
+            else jnp.zeros((kernel.shape[-1],), kernel.dtype),
+        }
+    }
+    ref_outputs = ref_conv.apply(ref_params, inputs)
+    np.testing.assert_allclose(outputs, ref_outputs, atol=1e-5)
+
+
+def test_patch_encoder_and_small_stem_with_film():
+    patch = PatchEncoder(use_film=True, patch_size=2, num_features=4)
+    obs = jnp.ones((1, 16, 16, 3))
+    cond = jnp.ones((1, 2))
+    variables = patch.init(jax.random.PRNGKey(1), obs, train=False, cond_var=cond)
+    out = patch.apply(variables, obs, train=False, cond_var=cond)
+    assert out.shape[-1] == 4
+
+    stem = SmallStem(
+        use_film=True,
+        patch_size=16,
+        features=(32, 64),
+        strides=(2, 2),
+        kernel_sizes=(3, 3),
+        padding=(1, 1),
+    )
+    stem_vars = stem.init(jax.random.PRNGKey(2), obs, train=False, cond_var=cond)
+    stem_out = stem.apply(stem_vars, obs, train=False, cond_var=cond)
+    assert stem_out.shape[-1] == stem.num_features
+
+
+def test_residual_unit_and_stage():
+    unit = ResidualUnit(features=32)
+    x = jnp.ones((1, 4, 4, 128))
+    vars_unit = unit.init(jax.random.PRNGKey(3), x)
+    out_unit = unit.apply(vars_unit, x)
+    assert out_unit.shape[-1] == 128
+
+    stage = ResNetStage(block_size=1, nout=32, first_stride=(1, 1))
+    vars_stage = stage.init(jax.random.PRNGKey(4), out_unit)
+    out_stage = stage.apply(vars_stage, out_unit)
+    assert out_stage.shape[-1] == 128
+
+
+def test_vit_resnet_variants():
+    model = ViTResnet(use_film=False, num_layers=(1, 1))
+    obs = jnp.ones((1, 8, 8, 3))
+    vars_model = model.init(jax.random.PRNGKey(5), obs, train=False)
+    out = model.apply(vars_model, obs, train=False)
+    assert out.ndim == 4
+
+    model_film = ResNet26FILM()
+    cond = jnp.ones((1, 4))
+    vars_film = model_film.init(jax.random.PRNGKey(6), obs, train=False, cond_var=cond)
+    out_film = model_film.apply(vars_film, obs, train=False, cond_var=cond)
+    assert out_film.shape[0] == obs.shape[0]
+
+    resnet26 = ResNet26()
+    vars_resnet26 = resnet26.init(jax.random.PRNGKey(7), obs, train=False)
+    out_resnet26 = resnet26.apply(vars_resnet26, obs, train=False)
+    assert out_resnet26.shape[0] == obs.shape[0]
+
+
+def test_small_stem_variants_inherit_patch_size():
+    obs = jnp.ones((1, 8, 8, 3))
+    stem16 = SmallStem16()
+    vars16 = stem16.init(jax.random.PRNGKey(8), obs, train=False)
+    out16 = stem16.apply(vars16, obs, train=False)
+    assert stem16.patch_size == 16
+    assert out16.ndim == 4
+
+    stem32 = SmallStem32()
+    vars32 = stem32.init(jax.random.PRNGKey(9), obs, train=False)
+    out32 = stem32.apply(vars32, obs, train=False)
+    assert stem32.patch_size == 32
+    assert out32.ndim == 4
+
+
+def test_vit_encoder_configs_return_modules():
+    inputs = jnp.ones((1, 4, 4, 3))
+    cond = jnp.ones((1, 4))
+    for name, factory in vit_encoder_configs.items():
+        module = factory()
+        assert isinstance(module, nn.Module)
+        kwargs = dict(train=False)
+        if getattr(module, "use_film", False):
+            kwargs["cond_var"] = cond
+        variables = module.init(jax.random.PRNGKey(hash(name) & 0xFFFF), inputs, **kwargs)
+        out = module.apply(variables, inputs, **kwargs)
+        assert out.ndim >= 3


### PR DESCRIPTION
## Summary
- add unit tests covering TokenGroup helpers, action heads, transformer blocks, diffusion heads, tokenizers, and ViT encoders under `crossformer/model/components`
- extend the testing TensorFlow shim so trajectory transform tests can exercise tf-style utilities without a real TF install

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf537b719c8329aeda0ed1a5ebce7b