### PR TITLE
Add comprehensive tests for grain data pipeline

### DIFF
--- a/crossformer/data/grain/tests/conftest.py
+++ b/crossformer/data/grain/tests/conftest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import numpy as np
+
+
+def make_synthetic_trajectory(length: int, *, language: str, seed: int = 0) -> dict:
+    rng = np.random.default_rng(seed)
+    observation = {
+        "img1": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "img2": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "img_wrist": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "state": {
+            "cartesian": rng.normal(size=(length, 6)).astype(np.float32),
+            "joints": rng.normal(size=(length, 7)).astype(np.float32),
+            "gripper": rng.normal(size=(length, 1)).astype(np.float32),
+        },
+        "language_embedding": rng.normal(size=(length, 8)).astype(np.float32),
+    }
+    return {
+        "observation": observation,
+        "action": rng.normal(size=(length, 4)).astype(np.float32),
+        "language_instruction": np.array([language] * length, dtype=object),
+    }
+
+
+def standardize_synthetic(traj: dict) -> dict:
+    obs = dict(traj["observation"])
+    state = obs.pop("state")
+    for key, value in state.items():
+        obs[f"state_{key}"] = value
+    traj = dict(traj)
+    traj["observation"] = obs
+    return traj
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))

--- a/crossformer/data/grain/tests/test_builders_module.py
+++ b/crossformer/data/grain/tests/test_builders_module.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from crossformer.data.grain import builders
+from crossformer.data.grain.tests.conftest import make_synthetic_trajectory, standardize_synthetic
+from crossformer.utils.spec import ModuleSpec
+
+
+@pytest.fixture
+def dataset_config(tmp_path: Path) -> builders.GrainDatasetConfig:
+    trajectories = [
+        make_synthetic_trajectory(5, language="pick", seed=0),
+        make_synthetic_trajectory(4, language="place", seed=1),
+        make_synthetic_trajectory(3, language="", seed=2),
+    ]
+    return builders.GrainDatasetConfig(
+        name="spec_dataset",
+        source=lambda: trajectories,
+        standardize_fn=ModuleSpec.create(standardize_synthetic),
+        image_obs_keys={"main": "img1", "aux": "img2", "wrist": "img_wrist"},
+        depth_obs_keys={},
+        proprio_obs_keys={
+            "cartesian": "state_cartesian",
+            "joints": "state_joints",
+            "gripper": "state_gripper",
+            "embedding": "language_embedding",
+        },
+        proprio_obs_dims={"cartesian": 6, "joints": 7, "gripper": 1, "embedding": 8},
+        language_key="language_instruction",
+        statistics_save_dir=str(tmp_path / "stats"),
+        action_normalization_mask=[True, False, True, True],
+        skip_norm_keys=["proprio_embedding"],
+        filter_fns=[lambda traj: traj["language_instruction"][0] != ""],
+    )
+
+
+def test_build_trajectory_dataset_applies_standardization(dataset_config: builders.GrainDatasetConfig):
+    dataset, stats = builders.build_trajectory_dataset(dataset_config)
+    assert len(dataset) == 2
+    first = dataset[0]
+    assert set(first["observation"].keys()) >= {
+        "image_main",
+        "image_aux",
+        "image_wrist",
+        "proprio_cartesian",
+        "proprio_joints",
+        "proprio_gripper",
+        "proprio_embedding",
+        "timestep",
+    }
+    assert first["task"]["language_instruction"].shape[0] == first["action"].shape[0]
+    assert np.isclose(first["action"].mean(axis=0)[1], 0.0, atol=1.0)
+    assert first["observation"]["proprio_embedding"].dtype == np.float32
+    assert stats.num_trajectories == 2
+    assert dataset.dataset_statistics.action.mean.shape == (4,)
+
+
+def test_build_trajectory_dataset_with_existing_statistics(
+    dataset_config: builders.GrainDatasetConfig, tmp_path: Path
+):
+    dataset, stats = builders.build_trajectory_dataset(dataset_config)
+    stats_path = tmp_path / "precomputed.json"
+    stats_path.write_text(json.dumps(stats.to_json()))
+
+    dataset_config.dataset_statistics = str(stats_path)
+    dataset_config.force_recompute_dataset_statistics = False
+    dataset2, stats2 = builders.build_trajectory_dataset(dataset_config)
+    assert len(dataset2) == len(dataset)
+    assert np.allclose(stats2.action.mean, stats.action.mean)
+
+
+@pytest.mark.parametrize(
+    "input_value, expected",
+    [
+        ([], []),
+        ([0, 1, 2], [0, 1, 2]),
+    ],
+)
+def test_iter_source_handles_sequences(input_value, expected):
+    config = builders.GrainDatasetConfig(name="iter", source=input_value)
+    source = builders._resolve_source(config.source)
+    items = list(builders._iter_source(source))
+    assert len(items) == len(expected)
+
+
+def test_sample_match_key_finds_patterns():
+    traj = {"task_language": "hello", "other": 1}
+    assert builders._sample_match_key(traj, "task*") == "hello"
+    with pytest.raises(ValueError):
+        builders._sample_match_key(traj, "missing*")
+
+
+def test_load_dataset_statistics_from_mapping(dataset_config: builders.GrainDatasetConfig):
+    dataset, stats = builders.build_trajectory_dataset(dataset_config)
+    mapping = stats.to_json()
+    dataset_config.dataset_statistics = mapping
+    dataset_config.force_recompute_dataset_statistics = False
+    dataset2, stats2 = builders.build_trajectory_dataset(dataset_config)
+    assert np.allclose(stats2.action.mean, stats.action.mean)

--- a/crossformer/data/grain/tests/test_metadata_module.py
+++ b/crossformer/data/grain/tests/test_metadata_module.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from crossformer.data.grain import metadata
+
+
+@pytest.fixture
+def simple_stats(tmp_path: Path) -> metadata.DatasetStatistics:
+    action = np.array([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]], dtype=np.float32)
+    proprio = np.array([[0.5, 1.5], [1.5, 2.5], [2.5, 3.5]], dtype=np.float32)
+    trajectories = [
+        {"action": action, "observation": {"proprio_arm": proprio}},
+        {"action": action + 1.0, "observation": {"proprio_arm": proprio + 1.0}},
+    ]
+    stats = metadata.compute_dataset_statistics(
+        trajectories,
+        proprio_keys=["proprio_arm"],
+        hash_dependencies=["unit-test"],
+        save_dir=tmp_path,
+        force_recompute=True,
+    )
+    return stats
+
+
+def test_array_statistics_roundtrip(simple_stats: metadata.DatasetStatistics, tmp_path: Path):
+    json_path = tmp_path / "stats.json"
+    json_path.write_text(json.dumps(simple_stats.to_json()))
+    loaded = metadata.DatasetStatistics.from_json(json.loads(json_path.read_text()))
+    assert np.allclose(loaded.action.mean, simple_stats.action.mean)
+    assert loaded.num_transitions == simple_stats.num_transitions
+    assert "proprio_arm" in loaded.proprio
+
+
+def test_compute_dataset_statistics_caches_results(simple_stats: metadata.DatasetStatistics, tmp_path: Path):
+    cache_files = list(tmp_path.glob("dataset_statistics_*.json"))
+    assert len(cache_files) == 1
+    cached = metadata.compute_dataset_statistics(
+        [],
+        proprio_keys=["proprio_arm"],
+        hash_dependencies=["unit-test"],
+        save_dir=tmp_path,
+        force_recompute=False,
+    )
+    assert np.allclose(cached.action.mean, simple_stats.action.mean)
+    assert cached.num_trajectories == simple_stats.num_trajectories
+
+
+def test_normalize_action_and_proprio_with_mask(simple_stats: metadata.DatasetStatistics):
+    trajectory = {
+        "action": np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32),
+        "observation": {"proprio_arm": np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)},
+    }
+    normalized = metadata.normalize_action_and_proprio(
+        trajectory,
+        metadata=simple_stats,
+        normalization_type=metadata.NormalizationType.NORMAL,
+        proprio_keys=["proprio_arm"],
+        action_mask=[True, False],
+    )
+    assert normalized["action"].shape == (2, 2)
+    # second dimension should remain equal to original because mask disables normalization
+    assert np.allclose(normalized["action"][:, 1], trajectory["action"][:, 1])
+    assert not np.allclose(normalized["action"][:, 0], trajectory["action"][:, 0])
+    assert np.allclose(normalized["observation"]["proprio_arm"].mean(), 0.0, atol=1e-5)
+
+
+def test_normalize_action_and_proprio_bounds_mode(simple_stats: metadata.DatasetStatistics):
+    trajectory = {
+        "action": np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32),
+        "observation": {"proprio_arm": np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)},
+    }
+    normalized = metadata.normalize_action_and_proprio(
+        trajectory,
+        metadata=simple_stats,
+        normalization_type=metadata.NormalizationType.BOUNDS,
+        proprio_keys=["proprio_arm"],
+        skip_norm_keys=["proprio_arm"],
+    )
+    assert normalized["observation"]["proprio_arm"].shape == (2, 2)
+    assert np.all((-1.001 <= normalized["action"]) & (normalized["action"] <= 1.001))
+
+
+def test_normalize_action_and_proprio_invalid_type(simple_stats: metadata.DatasetStatistics):
+    with pytest.raises(ValueError):
+        metadata.normalize_action_and_proprio(
+            {"action": np.zeros((2, 2), dtype=np.float32)},
+            metadata=simple_stats,
+            normalization_type="unknown",
+            proprio_keys=[],
+        )
+
+
+def test_normalize_action_and_proprio_mask_length_mismatch(simple_stats: metadata.DatasetStatistics):
+    with pytest.raises(ValueError):
+        metadata.normalize_action_and_proprio(
+            {"action": np.zeros((2, 3), dtype=np.float32)},
+            metadata=simple_stats,
+            normalization_type=metadata.NormalizationType.NORMAL,
+            proprio_keys=[],
+            action_mask=[True, False],
+        )

--- a/crossformer/data/grain/tests/test_runtime_options.py
+++ b/crossformer/data/grain/tests/test_runtime_options.py
@@ -1,0 +1,47 @@
+import grain.python as gp
+import pytest
+
+from crossformer.data.grain import sharding, threading
+
+
+def test_create_shard_options_defaults():
+    options = sharding.create_shard_options()
+    assert isinstance(options, gp.ShardOptions)
+    assert options.shard_index == 0
+    assert options.shard_count == 1
+
+
+def test_create_shard_options_with_parameters():
+    options = sharding.create_shard_options(shard_count=4, shard_index=2, drop_remainder=True)
+    assert options.shard_index == 2
+    assert options.shard_count == 4
+    assert options.drop_remainder is True
+
+
+def test_create_shard_options_jax_process():
+    options = sharding.create_shard_options(use_jax_process=True)
+    assert isinstance(options, gp.ShardByJaxProcess)
+
+
+def test_create_shard_options_missing_index():
+    with pytest.raises(ValueError):
+        sharding.create_shard_options(shard_count=2)
+
+
+def test_create_read_options_overrides():
+    options = threading.create_read_options(num_threads=8, prefetch_buffer_size=16)
+    assert isinstance(options, gp.ReadOptions)
+    assert options.num_threads == 8
+    assert options.prefetch_buffer_size == 16
+
+
+def test_create_multiprocessing_options_overrides():
+    options = threading.create_multiprocessing_options(
+        num_workers=4,
+        per_worker_buffer_size=32,
+        enable_profiling=True,
+    )
+    assert isinstance(options, gp.MultiprocessingOptions)
+    assert options.num_workers == 4
+    assert options.per_worker_buffer_size == 32
+    assert options.enable_profiling is True

--- a/crossformer/data/grain/tests/test_transforms_module.py
+++ b/crossformer/data/grain/tests/test_transforms_module.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from crossformer.data.grain import transforms
+
+
+@pytest.fixture
+def base_trajectory() -> dict:
+    length = 5
+    window = 3
+    rng = np.random.default_rng(0)
+    observation = {
+        "rgb": rng.integers(0, 255, size=(length, 4, 4, 3), dtype=np.uint8),
+        "proprio": rng.normal(size=(length, 3)).astype(np.float32),
+    }
+    trajectory = {
+        "observation": observation,
+        "task": {"language_instruction": np.array(["pick"] * length, dtype=object)},
+        "action": rng.normal(size=(length, 2)).astype(np.float32),
+        "dataset_name": np.array(["demo"] * length, dtype=object),
+    }
+    trajectory = transforms.add_pad_mask_dict(trajectory)
+    trajectory = transforms.pad_actions_and_proprio(
+        trajectory, max_action_dim=3, max_proprio_dim=4
+    )
+    trajectory = transforms.chunk_action_and_observation(
+        trajectory, window_size=window, action_horizon=2
+    )
+    return trajectory
+
+
+def test_add_pad_mask_dict_creates_boolean_masks():
+    traj = {"observation": {"image": np.zeros((2, 2, 3), dtype=np.uint8)}}
+    result = transforms.add_pad_mask_dict(traj)
+    mask = result["observation"]["pad_mask_dict"]["image"]
+    assert mask.dtype == bool
+    assert np.all(mask)
+
+
+def test_add_head_action_mask_with_mapping(base_trajectory):
+    mapping = {"arm": ["demo"], "unused": ["other"]}
+    result = transforms.add_head_action_mask(base_trajectory, mapping)
+    assert set(result["action_head_masks"].keys()) == {"arm", "unused"}
+    assert np.all(result["action_head_masks"]["arm"])
+    assert not np.any(result["action_head_masks"]["unused"])
+
+
+def test_pad_actions_and_proprio_padding_behavior():
+    traj = {
+        "action": np.ones((2, 2), dtype=np.float32),
+        "observation": {"proprio": np.ones((2, 2), dtype=np.float32)},
+    }
+    padded = transforms.pad_actions_and_proprio(
+        traj, max_action_dim=4, max_proprio_dim=3
+    )
+    assert padded["action"].shape == (2, 4)
+    assert padded["observation"]["proprio"].shape == (2, 3)
+    assert np.all(padded["action_pad_mask"][:, :2])
+    assert not np.any(padded["action_pad_mask"][:, 2:])
+
+
+def test_chunk_action_and_observation_shapes(base_trajectory):
+    obs = base_trajectory["observation"]
+    assert obs["rgb"].shape == (5, 3, 4, 4, 3)
+    assert obs["timestep_pad_mask"].shape == (5, 3)
+    assert base_trajectory["action"].shape == (5, 3, 2, 3)
+    assert base_trajectory["action_pad_mask"].shape == (5, 3, 2, 3)
+    assert base_trajectory["observation"]["task_completed"].shape == (5, 3, 2)
+
+
+def test_chunk_action_and_observation_override_window():
+    traj = {
+        "observation": {"value": np.arange(4, dtype=np.float32)},
+        "action": np.ones((4, 1), dtype=np.float32),
+    }
+    chunked = transforms.chunk_action_and_observation(
+        transforms.add_pad_mask_dict(traj),
+        window_size=3,
+        action_horizon=1,
+        override_window_size=2,
+    )
+    mask = chunked["observation"]["timestep_pad_mask"]
+    assert np.all(~mask[:, 0])
+    assert np.all(mask[:, -1])
+
+
+def test_subsample_random_selection():
+    traj = {
+        "action": np.arange(10)[:, None],
+        "observation": {"value": np.arange(10)[:, None]},
+    }
+    rng = np.random.default_rng(0)
+    subsampled = transforms.subsample(traj, length=5, rng=rng)
+    assert subsampled["action"].shape[0] == 5
+    assert np.unique(subsampled["action"]).shape[0] == 5
+
+
+def test_zero_out_future_proprio_raises_on_invalid_shape():
+    traj = {"observation": {"proprio": np.ones((3,), dtype=np.float32)}}
+    with pytest.raises(ValueError):
+        transforms.zero_out_future_proprio(traj)
+
+
+def test_zero_out_future_proprio_on_chunked(base_trajectory):
+    updated = transforms.zero_out_future_proprio(base_trajectory)
+    proprio = updated["observation"].get("proprio")
+    if proprio is not None:
+        assert np.all(proprio[:, 1:] == 0)
+
+
+def test_flatten_trajectory_emits_frames(base_trajectory):
+    frames = list(transforms.flatten_trajectory(base_trajectory))
+    assert len(frames) == 5
+    first = frames[0]
+    assert first["action"].shape == (3, 2, 3)
+    assert first["observation"]["rgb"].shape == (3, 4, 4, 3)
+    assert first["dataset_name"] == "demo"
+
+
+def test_drop_empty_language_raises():
+    traj = {
+        "action": np.zeros((2, 1)),
+        "task": {"language_instruction": np.array(["", ""], dtype=object)},
+    }
+    with pytest.raises(ValueError):
+        transforms.drop_empty_language(traj)
+
+
+def test_uniform_goal_relabel_adds_goal():
+    traj = {
+        "action": np.zeros((3, 1), dtype=np.float32),
+        "observation": {"image": np.arange(9, dtype=np.float32).reshape(3, 3)},
+    }
+    rng = np.random.default_rng(0)
+    relabeled = transforms.uniform_goal_relabel(traj, rng=rng)
+    assert "task" in relabeled
+    assert "image" in relabeled["task"]
+
+
+def test_maybe_cast_dtype_changes_type():
+    value = np.array([1, 2, 3], dtype=np.int32)
+    cast = transforms.maybe_cast_dtype(value, np.float32)
+    assert cast.dtype == np.float32
+    # no-op when dtype already matches
+    same = transforms.maybe_cast_dtype(cast, np.float32)
+    assert same.dtype == np.float32

--- a/crossformer/data/grain/tests/test_utils_module.py
+++ b/crossformer/data/grain/tests/test_utils_module.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+
+from crossformer.data.grain import utils
+
+
+def test_tree_map_applies_function_recursively():
+    tree = {"a": 1, "b": {"c": 2, "d": 3}}
+    result = utils.tree_map(lambda x: x * 2, tree)
+    assert result == {"a": 2, "b": {"c": 4, "d": 6}}
+    assert tree == {"a": 1, "b": {"c": 2, "d": 3}}
+
+
+def test_tree_merge_prefers_rightmost_values():
+    base = {"a": 1, "nested": {"left": 5, "shared": {"x": 1}}}
+    override = {"nested": {"right": 6, "shared": {"y": 2}}, "extra": 3}
+    merged = utils.tree_merge(base, override)
+    assert merged == {
+        "a": 1,
+        "nested": {"left": 5, "right": 6, "shared": {"x": 1, "y": 2}},
+        "extra": 3,
+    }
+
+
+def test_clone_structure_preserves_numpy_arrays():
+    array = np.arange(6, dtype=np.float32).reshape(2, 3)
+    original = {"x": array, "nested": {"y": [1, 2, 3]}}
+    clone = utils.clone_structure(original)
+    assert np.array_equal(clone["x"], array)
+    assert clone["x"] is not array
+    clone["nested"]["y"].append(4)
+    assert original["nested"]["y"] == [1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (np.zeros((2, 2), dtype=np.float32), np.ones((2, 2), dtype=bool)),
+        (np.array(["", "foo"], dtype="<U3"), np.array([True, False])),
+        (np.array([True, False], dtype=bool), np.array([False, True])),
+    ],
+)
+def test_is_padding_scalar_cases(value, expected):
+    mask = utils.is_padding(value)
+    assert np.array_equal(mask, expected)
+
+
+def test_is_padding_nested_dict_combines_masks():
+    nested = {"a": np.zeros((2,), dtype=np.float32), "b": np.array(["", ""], dtype="<U1")}
+    mask = utils.is_padding(nested)
+    assert np.array_equal(mask, np.array([True, True]))
+
+
+def test_to_padding_matches_dtype():
+    assert utils.to_padding(np.array([1, 2], dtype=np.int32)).dtype == np.int32
+    assert utils.to_padding(np.array(["a"], dtype="U1")).dtype.kind in {"U", "S"}
+    assert utils.to_padding(np.array([True, False], dtype=bool)).dtype == bool
+
+
+def test_ensure_numpy_and_as_dict():
+    assert isinstance(utils.ensure_numpy([1, 2, 3]), np.ndarray)
+    mapping = utils.as_dict({"a": 1})
+    mapping["b"] = 2
+    assert mapping == {"a": 1, "b": 2}
+    assert utils.as_dict(None) == {}


### PR DESCRIPTION
## Summary
- add reusable synthetic trajectory helpers for consistent grain test data
- add focused unit tests covering grain utils, metadata, transforms, builders, and runtime option helpers
- expand pipeline tests to validate single and interleaved dataset construction and frame transforms using the synthetic spec

## Testing
- pytest crossformer/data/grain/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d046d2ee4c832981d950858c057f4c