### PR TITLE
Fix JAX scalar comparisons in action head tests

### DIFF
--- a/tests/test_action_heads.py
+++ b/tests/test_action_heads.py
@@ -125,8 +125,8 @@ def test_continuous_action_head_forward_and_masks():
     )
 
     assert jnp.allclose(masked_loss, masked_loss_modified)
-    assert unmasked_loss > masked_loss
-    assert metrics["loss"] == masked_loss
+    assert unmasked_loss.item() > masked_loss.item()
+    assert jnp.allclose(metrics["loss"], masked_loss)
     assert set(metrics) == {"loss", "mse", "lsign"}
 
 
@@ -202,8 +202,8 @@ def test_diffusion_action_head_end_to_end():
     )
 
     assert jnp.allclose(masked_loss, masked_loss_modified)
-    assert unmasked_loss > masked_loss
-    assert metrics["loss"] == masked_loss
+    assert unmasked_loss.item() > masked_loss.item()
+    assert jnp.allclose(metrics["loss"], masked_loss)
     assert set(metrics) == {"loss", "mse", "lsign"}
 
     sampled = head.apply(
@@ -290,8 +290,8 @@ def test_flow_matching_action_head_end_to_end():
     )
 
     assert jnp.allclose(masked_loss, masked_loss_modified)
-    assert unmasked_loss > masked_loss
-    assert metrics["loss"] == masked_loss
+    assert unmasked_loss.item() > masked_loss.item()
+    assert jnp.allclose(metrics["loss"], masked_loss)
     assert set(metrics) == {"loss", "mse", "lsign"}
 
     samples = head.apply(


### PR DESCRIPTION
## Summary
- avoid ambiguous truthiness by converting scalar comparisons in the action head tests to use `.item()` and `jnp.allclose`

## Testing
- pytest tests/test_action_heads.py *(fails: ModuleNotFoundError: No module named 'jax')*

------
https://chatgpt.com/codex/tasks/task_e_68d04a5fe12c8329b2aa46bf662b79f3