### PR TITLE
Add user-friendly examples that mirror existing tests

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,5 @@
+"""User-facing walkthroughs that mirror the automated tests."""
+
+from . import grain, model  # noqa: F401
+
+__all__ = ["grain", "model"]

--- a/examples/ex_action_heads_and_flow.py
+++ b/examples/ex_action_heads_and_flow.py
@@ -1,0 +1,157 @@
+"""Action head walkthrough mirroring :mod:`tests.test_action_heads_and_flow`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from crossformer.model.components.action_heads import (
+    ContinuousActionHead,
+    DiffusionActionHead,
+    FlowMatchingActionHead,
+)
+from crossformer.model.components.base import TokenGroup
+
+
+def _make_transformer_outputs(
+    batch_size: int = 2,
+    window_size: int = 3,
+    num_tokens: int = 4,
+    embed_dim: int = 6,
+) -> dict[str, TokenGroup]:
+    """Assemble a tiny token stream that mimics encoder outputs."""
+    tokens = jnp.linspace(
+        0.0,
+        1.0,
+        batch_size * window_size * num_tokens * embed_dim,
+        dtype=jnp.float32,
+    ).reshape(batch_size, window_size, num_tokens, embed_dim)
+    mask = jnp.ones((batch_size, window_size, num_tokens), dtype=bool)
+    return {"obs": TokenGroup(tokens=tokens, mask=mask)}
+
+
+def continuous_head_demo() -> dict[str, jnp.ndarray]:
+    """Show mean prediction, sampling, and loss masking for regression heads."""
+    outputs = _make_transformer_outputs()
+    head = ContinuousActionHead(
+        readout_key="obs",
+        action_horizon=2,
+        action_dim=3,
+        max_action=1.5,
+    )
+    variables = head.init(jax.random.PRNGKey(0), outputs, train=False)
+    mean = head.apply(variables, outputs, train=False)
+
+    timestep_mask = jnp.ones(mean.shape[:2], dtype=bool)
+    action_mask = jnp.ones_like(mean, dtype=bool)
+    loss, metrics = head.apply(
+        variables,
+        outputs,
+        mean,
+        timestep_mask,
+        action_mask,
+        method=head.loss,
+    )
+    samples = head.apply(
+        variables,
+        outputs,
+        sample_shape=(2,),
+        train=False,
+        method=head.predict_action,
+    )
+    return {"mean": mean, "samples": samples, "loss": loss, "metrics": metrics}
+
+
+def diffusion_head_demo() -> dict[str, jnp.ndarray]:
+    """Trace the denoising score network used for diffusion policies."""
+    outputs = _make_transformer_outputs(batch_size=2, window_size=2, num_tokens=3)
+    head = DiffusionActionHead(
+        readout_key="obs",
+        action_horizon=1,
+        action_dim=2,
+        diffusion_steps=4,
+        num_blocks=1,
+        time_dim=8,
+        hidden_dim=16,
+        dropout_rate=0.0,
+    )
+    variables = head.init(jax.random.PRNGKey(1), outputs, train=False)
+    time = jnp.zeros((2, 2, 1), dtype=jnp.float32)
+    noisy = jnp.zeros((2, 2, 2), dtype=jnp.float32)
+    eps = head.apply(variables, outputs, time=time, noisy_actions=noisy, train=False)
+
+    timestep_mask = jnp.ones((2, 2), dtype=bool)
+    action_mask = jnp.ones((2, 2, 1, 2), dtype=bool)
+    loss, metrics = head.apply(
+        variables,
+        outputs,
+        jnp.zeros_like(action_mask, dtype=jnp.float32),
+        timestep_mask,
+        action_mask,
+        method=head.loss,
+        rngs={"dropout": jax.random.PRNGKey(2)},
+    )
+    predicted = head.apply(
+        variables,
+        outputs,
+        sample_shape=(3,),
+        rng=jax.random.PRNGKey(3),
+        train=False,
+        method=head.predict_action,
+    )
+    return {"score": eps, "loss": loss, "metrics": metrics, "samples": predicted}
+
+
+def flow_matching_head_demo() -> dict[str, jnp.ndarray]:
+    """Simulate velocity predictions for the flow-matching action head."""
+    outputs = _make_transformer_outputs(batch_size=2, window_size=2, num_tokens=3)
+    head = FlowMatchingActionHead(
+        readout_key="obs",
+        action_horizon=2,
+        action_dim=2,
+        flow_steps=3,
+        num_blocks=1,
+        time_dim=8,
+        hidden_dim=16,
+        dropout_rate=0.0,
+    )
+    variables = head.init(jax.random.PRNGKey(4), outputs, train=False)
+    velocity = head.apply(
+        variables,
+        outputs,
+        time=jnp.full((2, 2, 1), 0.5, dtype=jnp.float32),
+        current=jnp.zeros((2, 2, 2, 2), dtype=jnp.float32),
+        train=False,
+    )
+
+    timestep_mask = jnp.ones((2, 2), dtype=bool)
+    action_mask = jnp.ones((2, 2, 2, 2), dtype=bool)
+    loss, metrics = head.apply(
+        variables,
+        outputs,
+        jnp.zeros_like(action_mask, dtype=jnp.float32),
+        timestep_mask,
+        action_mask,
+        method=head.loss,
+        rngs={"dropout": jax.random.PRNGKey(5)},
+    )
+    samples = head.apply(
+        variables,
+        outputs,
+        sample_shape=(2,),
+        rng=jax.random.PRNGKey(6),
+        train=False,
+        method=head.predict_action,
+    )
+    return {"velocity": velocity, "loss": loss, "metrics": metrics, "samples": samples}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    demos = {
+        "continuous": continuous_head_demo(),
+        "diffusion": diffusion_head_demo(),
+        "flow_matching": flow_matching_head_demo(),
+    }
+    for name, outputs in demos.items():
+        summary = {key: tuple(value.shape) for key, value in outputs.items() if hasattr(value, "shape")}
+        print(f"{name}: {summary}")

--- a/examples/ex_traj_transforms.py
+++ b/examples/ex_traj_transforms.py
@@ -1,0 +1,105 @@
+"""Trajectory transformation tour based on :mod:`tests.test_traj_transforms`."""
+
+from __future__ import annotations
+
+import numpy as np
+import tensorflow as tf
+
+from crossformer.data import traj_transforms
+
+
+def make_synthetic_trajectory(
+    length: int = 4,
+    obs_dim: int = 3,
+    action_dim: int = 2,
+    seed: int = 0,
+) -> dict[str, dict[str, tf.Tensor] | tf.Tensor]:
+    """Create TensorFlow-backed tensors that mirror the test fixtures."""
+    rng = np.random.default_rng(seed)
+    observation = {
+        "state": tf.constant(
+            rng.normal(size=(length, obs_dim)).astype(np.float32)
+        )
+    }
+    action = tf.constant(rng.normal(size=(length, action_dim)).astype(np.float32))
+    traj = {
+        "observation": observation,
+        "action": action,
+        "task": {},
+        "action_pad_mask": tf.ones((length, action_dim), dtype=tf.bool),
+    }
+    return traj
+
+
+def chunk_history_example() -> dict[str, tf.Tensor]:
+    """Chunk raw actions and observe the resulting masks."""
+    traj = make_synthetic_trajectory(length=5, obs_dim=2, action_dim=2)
+    chunked = traj_transforms.chunk_act_obs(
+        traj, window_size=3, action_horizon=2
+    )
+    state = chunked["observation"]["state"].numpy()
+    timestep_mask = chunked["observation"]["timestep_pad_mask"].numpy()
+    action = chunked["action"].numpy()
+    action_mask = chunked["action_pad_mask"].numpy()
+    return {
+        "state": state,
+        "timestep_mask": timestep_mask,
+        "action": action,
+        "action_mask": action_mask,
+    }
+
+
+def padding_and_goal_example() -> dict[str, tf.Tensor]:
+    """Pad trajectories, tag goals, and build per-head action masks."""
+    traj = make_synthetic_trajectory(length=4)
+    traj["observation"]["pad_mask_dict"] = {
+        "state": tf.constant([[True], [True], [False], [True]])
+    }
+    traj["task"]["timestep"] = tf.constant([3, 3, 3, 3], dtype=tf.int32)
+
+    padded = traj_transforms.pad_actions_and_proprio(
+        traj, max_action_dim=4, max_proprio_dim=None
+    )
+    chunked = traj_transforms.chunk_act_obs(
+        padded, window_size=3, action_horizon=2
+    )
+    with_masks = traj_transforms.add_head_action_mask(
+        chunked, head_to_dataset={"arm": tf.constant([b"demo"] * chunked["action"].shape[0])}
+    )
+    return {
+        "padded_action": padded["action"].numpy(),
+        "action_mask": padded["action_pad_mask"].numpy(),
+        "task_completed": chunked["observation"]["task_completed"].numpy(),
+        "head_mask": with_masks["action_head_masks"]["arm"].numpy(),
+    }
+
+
+def subsample_and_zero_proprio_example() -> dict[str, tf.Tensor]:
+    """Subsample frames then clear future proprio steps to zero."""
+    traj = make_synthetic_trajectory(length=6, obs_dim=3)
+    traj["observation"]["proprio"] = tf.constant(
+        np.arange(6 * 2 * 3, dtype=np.float32).reshape(6, 2, 3)
+    )
+    padded = traj_transforms.pad_actions_and_proprio(
+        traj, max_action_dim=3, max_proprio_dim=4
+    )
+    chunked = traj_transforms.chunk_act_obs(
+        padded, window_size=2, action_horizon=2
+    )
+    subsampled = traj_transforms.subsample(chunked, subsample_length=3)
+    proprio = traj_transforms.zero_out_future_proprio(subsampled)
+    pad_dict = traj_transforms.add_pad_mask_dict(proprio)
+    return {
+        "subsampled_len": subsampled["action"].shape[0],
+        "proprio": proprio["observation"]["proprio"].numpy(),
+        "pad_mask_dict": {
+            key: value.numpy()
+            for key, value in pad_dict["observation"]["pad_mask_dict"].items()
+        },
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("chunk_history", chunk_history_example()["state"].shape)
+    print("padding_and_goal", padding_and_goal_example()["padded_action"].shape)
+    print("subsample", subsample_and_zero_proprio_example()["subsampled_len"])

--- a/examples/grain/__init__.py
+++ b/examples/grain/__init__.py
@@ -1,0 +1,3 @@
+"""Examples for the Grain data input pipeline."""
+
+__all__: list[str] = []

--- a/examples/grain/ex_builders_module.py
+++ b/examples/grain/ex_builders_module.py
@@ -1,0 +1,122 @@
+"""Dataset builder how-to paired with :mod:`tests.grain.test_builders_module`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+from crossformer.data.grain import builders
+from crossformer.utils.spec import ModuleSpec
+
+
+def make_synthetic_trajectory(length: int, *, language: str, seed: int = 0) -> dict:
+    """Match the synthetic trajectories used inside the unit tests."""
+    rng = np.random.default_rng(seed)
+    observation = {
+        "img1": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "img2": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "img_wrist": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "state": {
+            "cartesian": rng.normal(size=(length, 6)).astype(np.float32),
+            "joints": rng.normal(size=(length, 7)).astype(np.float32),
+            "gripper": rng.normal(size=(length, 1)).astype(np.float32),
+        },
+        "language_embedding": rng.normal(size=(length, 8)).astype(np.float32),
+    }
+    return {
+        "observation": observation,
+        "action": rng.normal(size=(length, 4)).astype(np.float32),
+        "language_instruction": np.array([language] * length, dtype=object),
+    }
+
+
+def standardize_synthetic(traj: dict) -> dict:
+    """Flatten nested state dicts for downstream tokenizers."""
+    obs = dict(traj["observation"])
+    state = obs.pop("state")
+    for key, value in state.items():
+        obs[f"state_{key}"] = value
+    traj = dict(traj)
+    traj["observation"] = obs
+    return traj
+
+
+def dataset_config(tmp_dir: Path) -> builders.GrainDatasetConfig:
+    """Create a config identical to the one exercised by the tests."""
+    trajectories = [
+        make_synthetic_trajectory(5, language="pick", seed=0),
+        make_synthetic_trajectory(4, language="place", seed=1),
+        make_synthetic_trajectory(3, language="", seed=2),
+    ]
+    return builders.GrainDatasetConfig(
+        name="spec_dataset",
+        source=lambda: trajectories,
+        standardize_fn=ModuleSpec.create(standardize_synthetic),
+        image_obs_keys={"main": "img1", "aux": "img2", "wrist": "img_wrist"},
+        depth_obs_keys={},
+        proprio_obs_keys={
+            "cartesian": "state_cartesian",
+            "joints": "state_joints",
+            "gripper": "state_gripper",
+            "embedding": "language_embedding",
+        },
+        proprio_obs_dims={"cartesian": 6, "joints": 7, "gripper": 1, "embedding": 8},
+        language_key="language_instruction",
+        statistics_save_dir=str(tmp_dir / "stats"),
+        action_normalization_mask=[True, False, True, True],
+        skip_norm_keys=["proprio_embedding"],
+        filter_fns=[lambda traj: traj["language_instruction"][0] != ""],
+    )
+
+
+def build_dataset_demo(tmp_dir: Path) -> tuple[list, builders.DatasetStatistics]:
+    """Build the dataset and return both data and statistics."""
+    config = dataset_config(tmp_dir)
+    dataset, stats = builders.build_trajectory_dataset(config)
+    return dataset, stats
+
+
+def reuse_statistics_demo(config: builders.GrainDatasetConfig, stats: builders.DatasetStatistics, tmp_dir: Path) -> builders.DatasetStatistics:
+    """Persist statistics and reuse them without recomputation."""
+    stats_path = tmp_dir / "precomputed.json"
+    stats_path.write_text(json.dumps(stats.to_json()))
+    config.dataset_statistics = str(stats_path)
+    config.force_recompute_dataset_statistics = False
+    _, stats2 = builders.build_trajectory_dataset(config)
+    return stats2
+
+
+def iter_source_demo(source: Iterable) -> list:
+    """Resolve static sequences or callables into iterable datasets."""
+    resolved = builders._resolve_source(source)
+    return list(builders._iter_source(resolved))
+
+
+def sample_match_demo(traj: dict) -> str:
+    """Locate a key in a trajectory using wildcard patterns."""
+    return builders._sample_match_key(traj, "task*")
+
+
+def load_statistics_from_mapping_demo(config: builders.GrainDatasetConfig, stats: builders.DatasetStatistics) -> builders.DatasetStatistics:
+    """Load dataset statistics from an in-memory mapping."""
+    mapping = stats.to_json()
+    config.dataset_statistics = mapping
+    config.force_recompute_dataset_statistics = False
+    _, stats2 = builders.build_trajectory_dataset(config)
+    return stats2
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    tmp = Path("/tmp/crossformer_builders_example")
+    tmp.mkdir(parents=True, exist_ok=True)
+    dataset, stats = build_dataset_demo(tmp)
+    print("filtered trajectories", len(dataset))
+    stats_reused = reuse_statistics_demo(dataset_config(tmp), stats, tmp)
+    print("stats reused", np.allclose(stats_reused.action.mean, stats.action.mean))
+    print("iter source", iter_source_demo([0, 1, 2]))
+    print("sample match", sample_match_demo({"task_language": "hello", "other": 1}))
+    mapped = load_statistics_from_mapping_demo(dataset_config(tmp), stats)
+    print("mapped stats", mapped.action.mean.shape)

--- a/examples/grain/ex_metadata_module.py
+++ b/examples/grain/ex_metadata_module.py
@@ -1,0 +1,72 @@
+"""Dataset statistics tour matching :mod:`tests.grain.test_metadata_module`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from crossformer.data.grain import metadata
+
+
+def synthetic_trajectories() -> list[dict[str, object]]:
+    """Generate small trajectories with action and proprio streams."""
+    action = np.array([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]], dtype=np.float32)
+    proprio = np.array([[0.5, 1.5], [1.5, 2.5], [2.5, 3.5]], dtype=np.float32)
+    return [
+        {"action": action, "observation": {"proprio_arm": proprio}},
+        {"action": action + 1.0, "observation": {"proprio_arm": proprio + 1.0}},
+    ]
+
+
+def compute_stats_demo(tmp_dir: Path) -> metadata.DatasetStatistics:
+    """Compute and cache dataset statistics in a temp directory."""
+    stats = metadata.compute_dataset_statistics(
+        synthetic_trajectories(),
+        proprio_keys=["proprio_arm"],
+        hash_dependencies=["example"],
+        save_dir=tmp_dir,
+        force_recompute=True,
+    )
+    return stats
+
+
+def json_roundtrip_demo(stats: metadata.DatasetStatistics, tmp_dir: Path) -> metadata.DatasetStatistics:
+    """Write statistics to JSON and read them back into a dataclass."""
+    path = tmp_dir / "stats.json"
+    path.write_text(json.dumps(stats.to_json()))
+    return metadata.DatasetStatistics.from_json(json.loads(path.read_text()))
+
+
+def normalize_demo(stats: metadata.DatasetStatistics) -> dict[str, np.ndarray]:
+    """Normalize actions and proprio signals with masks and bounds."""
+    trajectory = {
+        "action": np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32),
+        "observation": {"proprio_arm": np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)},
+    }
+    normalized = metadata.normalize_action_and_proprio(
+        trajectory,
+        metadata=stats,
+        normalization_type=metadata.NormalizationType.NORMAL,
+        proprio_keys=["proprio_arm"],
+        action_mask=[True, False],
+    )
+    bounds = metadata.normalize_action_and_proprio(
+        trajectory,
+        metadata=stats,
+        normalization_type=metadata.NormalizationType.BOUNDS,
+        proprio_keys=["proprio_arm"],
+        skip_norm_keys=["proprio_arm"],
+    )
+    return {"normal": normalized["action"], "bounds": bounds["action"]}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    tmp = Path("/tmp/crossformer_metadata_example")
+    tmp.mkdir(parents=True, exist_ok=True)
+    stats = compute_stats_demo(tmp)
+    roundtrip = json_roundtrip_demo(stats, tmp)
+    print("num transitions", stats.num_transitions, roundtrip.num_transitions)
+    normalized = normalize_demo(stats)
+    print("normalized action", normalized["normal"].shape)

--- a/examples/grain/ex_pipelines.py
+++ b/examples/grain/ex_pipelines.py
@@ -1,0 +1,149 @@
+"""Dataset pipeline primer following :mod:`tests.grain.test_pipelines`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+from crossformer.data.grain import builders
+from crossformer.data.grain import pipelines
+from crossformer.data.grain import transforms
+from crossformer.utils.spec import ModuleSpec
+
+
+def make_synthetic_trajectory(length: int, *, language: str, seed: int = 0) -> dict:
+    """Create synthetic trajectories with multiple observation modalities."""
+    rng = np.random.default_rng(seed)
+    observation = {
+        "img1": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "img2": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "img_wrist": rng.integers(0, 255, size=(length, 16, 16, 3), dtype=np.uint8),
+        "state": {
+            "cartesian": rng.normal(size=(length, 6)).astype(np.float32),
+            "joints": rng.normal(size=(length, 7)).astype(np.float32),
+            "gripper": rng.normal(size=(length, 1)).astype(np.float32),
+        },
+        "language_embedding": rng.normal(size=(length, 8)).astype(np.float32),
+    }
+    return {
+        "observation": observation,
+        "action": rng.normal(size=(length, 4)).astype(np.float32),
+        "language_instruction": np.array([language] * length, dtype=object),
+    }
+
+
+def standardize_synthetic(traj: dict) -> dict:
+    """Flatten nested state dicts to match builder expectations."""
+    obs = dict(traj["observation"])
+    state = obs.pop("state")
+    for key, value in state.items():
+        obs[f"state_{key}"] = value
+    traj = dict(traj)
+    traj["observation"] = obs
+    return traj
+
+
+def pipeline_config(tmp_dir: Path) -> builders.GrainDatasetConfig:
+    """Assemble a :class:`GrainDatasetConfig` mirroring the test fixture."""
+    trajectories = [
+        make_synthetic_trajectory(5, language="pick", seed=0),
+        make_synthetic_trajectory(4, language="place", seed=1),
+        make_synthetic_trajectory(3, language="", seed=2),
+    ]
+    return builders.GrainDatasetConfig(
+        name="spec_dataset",
+        source=lambda: trajectories,
+        standardize_fn=ModuleSpec.create(standardize_synthetic),
+        image_obs_keys={"main": "img1", "aux": "img2", "wrist": "img_wrist"},
+        depth_obs_keys={},
+        proprio_obs_keys={
+            "cartesian": "state_cartesian",
+            "joints": "state_joints",
+            "gripper": "state_gripper",
+        },
+        proprio_obs_dims={"cartesian": 6, "joints": 7, "gripper": 1},
+        language_key="language_instruction",
+        statistics_save_dir=str(tmp_dir / "stats"),
+    )
+
+
+def single_dataset_demo(tmp_dir: Path) -> pipelines.GrainDataset:
+    """Build a single dataset pipeline with post-chunk transforms."""
+    config = pipeline_config(tmp_dir)
+    return pipelines.make_single_dataset(
+        config,
+        train=False,
+        traj_transform_kwargs={
+            "window_size": 3,
+            "action_horizon": 2,
+            "skip_unlabeled": True,
+            "goal_relabeling_strategy": "uniform",
+            "max_action": 10.0,
+            "max_proprio": 10.0,
+            "post_chunk_transforms": [ModuleSpec.create(transforms.zero_out_future_proprio)],
+            "head_to_dataset": {"arm": [config.name]},
+        },
+        shuffle_buffer_size=3,
+        seed=7,
+    )
+
+
+def frame_transform_demo(dataset: Iterable[dict]) -> list[dict]:
+    """Annotate frames using :func:`pipelines.apply_frame_transforms`."""
+    def annotate(frame: dict) -> dict:
+        frame = dict(frame)
+        frame["annotated"] = True
+        return frame
+
+    transformed = pipelines.apply_frame_transforms(
+        dataset,
+        [ModuleSpec.create(annotate)],
+    )
+    return list(transformed)
+
+
+def interleaved_dataset_demo(tmp_dir: Path) -> pipelines.InterleavedDataset:
+    """Mix two dataset configs with sampling weights."""
+    cfg_a = builders.GrainDatasetConfig(
+        name="dataset_a",
+        source=[make_synthetic_trajectory(4, language="alpha", seed=3)],
+        standardize_fn=ModuleSpec.create(standardize_synthetic),
+        image_obs_keys={"main": "img1"},
+        depth_obs_keys={},
+        proprio_obs_keys={"cartesian": "state_cartesian"},
+        proprio_obs_dims={"cartesian": 6},
+        language_key="language_instruction",
+        statistics_save_dir=str(tmp_dir / "stats_a"),
+    )
+    cfg_b = builders.GrainDatasetConfig(
+        name="dataset_b",
+        source=[make_synthetic_trajectory(3, language="beta", seed=4)],
+        standardize_fn=ModuleSpec.create(standardize_synthetic),
+        image_obs_keys={"main": "img1"},
+        depth_obs_keys={},
+        proprio_obs_keys={"cartesian": "state_cartesian"},
+        proprio_obs_dims={"cartesian": 6},
+        language_key="language_instruction",
+        statistics_save_dir=str(tmp_dir / "stats_b"),
+    )
+    return pipelines.make_interleaved_dataset(
+        [cfg_a, cfg_b],
+        train=False,
+        sample_weights=[0.75, 0.25],
+        shuffle_buffer_size=4,
+        seed=9,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    tmp = Path("/tmp/crossformer_pipelines_example")
+    tmp.mkdir(parents=True, exist_ok=True)
+    single = single_dataset_demo(tmp)
+    frames = list(single.dataset)
+    print("single dataset frames", len(frames))
+    annotated = frame_transform_demo(frames)
+    print("annotated flag", annotated[0]["annotated"])
+    interleaved = interleaved_dataset_demo(tmp)
+    print("interleaved keys", list(interleaved.statistics.keys()))

--- a/examples/grain/ex_runtime_options.py
+++ b/examples/grain/ex_runtime_options.py
@@ -1,0 +1,39 @@
+"""Runtime configuration guide for Grain I/O, echoing :mod:`tests.grain.test_runtime_options`."""
+
+from __future__ import annotations
+
+import grain.python as gp
+
+from crossformer.data.grain import sharding
+from crossformer.data.grain import threading
+
+
+def shard_options_demo() -> tuple[gp.ShardOptions, gp.ShardOptions, gp.ShardByJaxProcess]:
+    """Show default, parameterized, and JAX-aware sharding options."""
+    default = sharding.create_shard_options()
+    manual = sharding.create_shard_options(shard_count=4, shard_index=2, drop_remainder=True)
+    jax_process = sharding.create_shard_options(use_jax_process=True)
+    return default, manual, jax_process
+
+
+def read_options_demo() -> gp.ReadOptions:
+    """Override reader parallelism and buffering."""
+    return threading.create_read_options(num_threads=8, prefetch_buffer_size=16)
+
+
+def multiprocessing_options_demo() -> gp.MultiprocessingOptions:
+    """Tune worker pool behaviour for multiprocess readers."""
+    return threading.create_multiprocessing_options(
+        num_workers=4,
+        per_worker_buffer_size=32,
+        enable_profiling=True,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    default, manual, jax_process = shard_options_demo()
+    print("default shards", default.shard_count, default.shard_index)
+    print("manual shards", manual.shard_count, manual.shard_index, manual.drop_remainder)
+    print("jax process", type(jax_process).__name__)
+    print("read options", read_options_demo().num_threads)
+    print("multiprocessing", multiprocessing_options_demo().num_workers)

--- a/examples/grain/ex_transforms_module.py
+++ b/examples/grain/ex_transforms_module.py
@@ -1,0 +1,96 @@
+"""Pipeline transform examples mirroring :mod:`tests.grain.test_transforms_module`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from crossformer.data.grain import transforms
+
+
+def make_base_trajectory(length: int = 5, seed: int = 0) -> dict:
+    """Create a trajectory with rgb, proprio, and language fields."""
+    rng = np.random.default_rng(seed)
+    observation = {
+        "rgb": rng.integers(0, 255, size=(length, 4, 4, 3), dtype=np.uint8),
+        "proprio": rng.normal(size=(length, 3)).astype(np.float32),
+    }
+    trajectory = {
+        "observation": observation,
+        "task": {"language_instruction": np.array(["pick"] * length, dtype=object)},
+        "action": rng.normal(size=(length, 2)).astype(np.float32),
+        "dataset_name": np.array(["demo"] * length, dtype=object),
+    }
+    trajectory = transforms.add_pad_mask_dict(trajectory)
+    trajectory = transforms.pad_actions_and_proprio(
+        trajectory, max_action_dim=3, max_proprio_dim=4
+    )
+    trajectory = transforms.chunk_action_and_observation(
+        trajectory, window_size=3, action_horizon=2
+    )
+    return trajectory
+
+
+def pad_mask_demo() -> dict[str, np.ndarray]:
+    """Ensure pad mask dictionaries store boolean arrays per modality."""
+    traj = {"observation": {"image": np.zeros((2, 2, 3), dtype=np.uint8)}}
+    result = transforms.add_pad_mask_dict(traj)
+    return {"image": result["observation"]["pad_mask_dict"]["image"]}
+
+
+def head_mask_demo(traj: dict) -> np.ndarray:
+    """Apply head-specific dataset filtering via :func:`add_head_action_mask`."""
+    mapping = {"arm": ["demo"], "unused": ["other"]}
+    result = transforms.add_head_action_mask(traj, mapping)
+    return result["action_head_masks"]["arm"]
+
+
+def chunk_shape_demo(traj: dict) -> dict[str, tuple[int, ...]]:
+    """Inspect the shapes produced by chunking actions and observations."""
+    return {
+        "rgb": traj["observation"]["rgb"].shape,
+        "timestep_mask": traj["observation"]["timestep_pad_mask"].shape,
+        "action": traj["action"].shape,
+        "action_mask": traj["action_pad_mask"].shape,
+        "task_completed": traj["observation"]["task_completed"].shape,
+    }
+
+
+def subsample_demo(traj: dict) -> int:
+    """Randomly subsample frames using :func:`subsample`."""
+    rng = np.random.default_rng(0)
+    subsampled = transforms.subsample(traj, length=3, rng=rng)
+    return subsampled["action"].shape[0]
+
+
+def flatten_demo(traj: dict) -> list[dict]:
+    """Flatten the chunked trajectory into per-timestep frames."""
+    return list(transforms.flatten_trajectory(traj))
+
+
+def goal_relabel_demo() -> dict:
+    """Relabel goals uniformly to augment data."""
+    traj = {
+        "action": np.zeros((3, 1), dtype=np.float32),
+        "observation": {"image": np.arange(9, dtype=np.float32).reshape(3, 3)},
+    }
+    rng = np.random.default_rng(0)
+    return transforms.uniform_goal_relabel(traj, rng=rng)
+
+
+def dtype_cast_demo() -> tuple[np.ndarray, np.ndarray]:
+    """Demonstrate dtype casting helper used before chunking."""
+    values = np.array([1, 2, 3], dtype=np.int32)
+    cast = transforms.maybe_cast_dtype(values, np.float32)
+    same = transforms.maybe_cast_dtype(cast, np.float32)
+    return cast, same
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    base = make_base_trajectory()
+    print("pad mask", pad_mask_demo()["image"].dtype)
+    print("head mask", head_mask_demo(base))
+    print("shapes", chunk_shape_demo(base))
+    print("subsample length", subsample_demo(base))
+    print("flatten frames", len(flatten_demo(base)))
+    print("goal relabel keys", goal_relabel_demo().keys())
+    print("dtype cast", [arr.dtype for arr in dtype_cast_demo()])

--- a/examples/grain/ex_utils_module.py
+++ b/examples/grain/ex_utils_module.py
@@ -1,0 +1,68 @@
+"""Utility helpers overview inspired by :mod:`tests.grain.test_utils_module`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from crossformer.data.grain import utils
+
+
+def tree_map_demo() -> dict:
+    """Apply a lambda across nested dictionaries without mutation."""
+    tree = {"a": 1, "b": {"c": 2, "d": 3}}
+    result = utils.tree_map(lambda x: x * 2, tree)
+    return {"result": result, "original": tree}
+
+
+def tree_merge_demo() -> dict:
+    """Merge dictionaries preferring override values."""
+    base = {"a": 1, "nested": {"left": 5, "shared": {"x": 1}}}
+    override = {"nested": {"right": 6, "shared": {"y": 2}}, "extra": 3}
+    return utils.tree_merge(base, override)
+
+
+def clone_structure_demo() -> dict:
+    """Clone nested structures without sharing array references."""
+    array = np.arange(6, dtype=np.float32).reshape(2, 3)
+    original = {"x": array, "nested": {"y": [1, 2, 3]}}
+    clone = utils.clone_structure(original)
+    clone["nested"]["y"].append(4)
+    return {"clone": clone, "original": original}
+
+
+def is_padding_demo() -> dict[str, np.ndarray]:
+    """Inspect padding detection for mixed data types."""
+    cases = {
+        "float": np.zeros((2, 2), dtype=np.float32),
+        "string": np.array(["", "foo"], dtype="<U3"),
+        "bool": np.array([True, False], dtype=bool),
+        "nested": {"a": np.zeros((2,), dtype=np.float32), "b": np.array(["", ""], dtype="<U1")},
+    }
+    return {name: utils.is_padding(value) for name, value in cases.items()}
+
+
+def to_padding_demo() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Convert values into padding tokens that mirror original dtypes."""
+    return (
+        utils.to_padding(np.array([1, 2], dtype=np.int32)),
+        utils.to_padding(np.array(["a"], dtype="U1")),
+        utils.to_padding(np.array([True, False], dtype=bool)),
+    )
+
+
+def ensure_numpy_demo() -> tuple[np.ndarray, dict]:
+    """Convert sequences to NumPy arrays and wrap mappings safely."""
+    array = utils.ensure_numpy([1, 2, 3])
+    mapping = utils.as_dict({"a": 1})
+    mapping["b"] = 2
+    empty = utils.as_dict(None)
+    return array, mapping | empty
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("tree map", tree_map_demo())
+    print("tree merge", tree_merge_demo())
+    print("clone", clone_structure_demo()["clone"]["nested"]["y"])
+    print("padding keys", list(is_padding_demo().keys()))
+    print("to padding dtypes", [arr.dtype for arr in to_padding_demo()])
+    print("ensure numpy", ensure_numpy_demo()[0].dtype)

--- a/examples/model/__init__.py
+++ b/examples/model/__init__.py
@@ -1,0 +1,5 @@
+"""Component-level examples for CrossFormer models."""
+
+from . import components  # noqa: F401
+
+__all__ = ["components"]

--- a/examples/model/components/__init__.py
+++ b/examples/model/components/__init__.py
@@ -1,0 +1,3 @@
+"""Examples dedicated to the building blocks in :mod:`crossformer.model.components`."""
+
+__all__: list[str] = []

--- a/examples/model/components/ex_action_heads.py
+++ b/examples/model/components/ex_action_heads.py
@@ -1,0 +1,112 @@
+"""Focused action head snippets inspired by :mod:`tests.model.components.test_action_heads`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from crossformer.model.components.action_heads import (
+    ContinuousActionHead,
+    DiffusionActionHead,
+    L1ActionHead,
+    MSEActionHead,
+    continuous_loss,
+)
+from crossformer.model.components.base import TokenGroup
+
+
+def _make_token_group(batch: int = 2, window: int = 3, tokens: int = 4, dim: int = 8) -> dict[str, TokenGroup]:
+    """Utility that mirrors the fixture used throughout the tests."""
+    values = jnp.linspace(0, 1, batch * window * tokens * dim).reshape(batch, window, tokens, dim)
+    mask = jnp.ones((batch, window, tokens), dtype=bool)
+    return {"obs": TokenGroup(tokens=values, mask=mask)}
+
+
+def loss_metric_demo() -> dict[str, jnp.ndarray]:
+    """Compare mean squared and L1 losses with shared masks."""
+    pred = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    target = jnp.array([[2.0, 2.0], [1.0, 6.0]])
+    mask = jnp.array([[1.0, 0.0], [1.0, 1.0]])
+    mse_loss, mse_metrics = continuous_loss(pred, target, mask, loss_type="mse")
+    l1_loss, _ = continuous_loss(pred, target, mask, loss_type="l1")
+    return {"mse": mse_loss, "metrics": mse_metrics["lsign"], "l1": l1_loss}
+
+
+def continuous_head_pool_demo(pool_strategy: str = "mean") -> jnp.ndarray:
+    """Forward the regression head with either mean or pass pooling."""
+    outputs = _make_token_group()
+    if pool_strategy == "pass":
+        tokens = outputs["obs"].tokens.reshape(2, 3, 2, 16)
+        mask = jnp.ones((2, 3, 2), dtype=bool)
+        outputs = {"obs": TokenGroup(tokens=tokens, mask=mask)}
+
+    head = ContinuousActionHead(
+        readout_key="obs",
+        pool_strategy=pool_strategy,
+        action_horizon=2,
+        action_dim=3,
+    )
+    variables = head.init(jax.random.PRNGKey(0), outputs, train=True)
+    preds = head.apply(variables, outputs, train=True)
+    return preds
+
+
+def specialized_head_demo() -> tuple[int, int]:
+    """Confirm the light wrappers swap the loss function or pooling strategy."""
+    l1_head = L1ActionHead(readout_key="obs")
+    mse_head = MSEActionHead(readout_key="obs", action_horizon=1, action_dim=2)
+    outputs = _make_token_group()
+    l1_params = l1_head.init(jax.random.PRNGKey(1), outputs, train=False)
+    mse_params = mse_head.init(jax.random.PRNGKey(2), outputs, train=False)
+    l1_preds = l1_head.apply(l1_params, outputs, train=False)
+    mse_preds = mse_head.apply(mse_params, outputs, train=False)
+    return l1_preds.shape[-1], mse_preds.shape[-1]
+
+
+def diffusion_head_pipeline_demo() -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Perform score estimation, loss computation, and sampling in one go."""
+    outputs = _make_token_group()
+    head = DiffusionActionHead(
+        readout_key="obs",
+        action_horizon=1,
+        action_dim=2,
+        time_dim=8,
+        num_blocks=1,
+        hidden_dim=16,
+        diffusion_steps=4,
+        dropout_rate=0.0,
+    )
+    params = head.init(jax.random.PRNGKey(3), outputs, train=True)
+    time = jnp.zeros((2, 3, 1), dtype=jnp.int32)
+    noisy = jnp.zeros((2, 3, 2), dtype=jnp.float32)
+    score = head.apply(params, outputs, time, noisy, train=False)
+
+    actions = jnp.zeros((2, 3, 1, 2))
+    timestep_mask = jnp.ones((2, 3), dtype=bool)
+    action_mask = jnp.ones_like(actions, dtype=bool)
+    loss, metrics = head.apply(
+        params,
+        outputs,
+        actions,
+        timestep_mask,
+        action_mask,
+        method=head.loss,
+        rngs={"dropout": jax.random.PRNGKey(4)},
+    )
+    samples = head.apply(
+        params,
+        outputs,
+        rng=jax.random.PRNGKey(5),
+        sample_shape=(2,),
+        method=head.predict_action,
+    )
+    return score, loss, samples
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("loss demo", loss_metric_demo())
+    print("continuous mean", continuous_head_pool_demo("mean").shape)
+    print("continuous pass", continuous_head_pool_demo("pass").shape)
+    print("specialized", specialized_head_demo())
+    score, loss, samples = diffusion_head_pipeline_demo()
+    print("diffusion score", score.shape, "loss", loss.shape, "samples", samples.shape)

--- a/examples/model/components/ex_base.py
+++ b/examples/model/components/ex_base.py
@@ -1,0 +1,25 @@
+"""TokenGroup helpers drawn from :mod:`tests.model.components.test_base`."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from crossformer.model.components.base import TokenGroup
+
+
+def create_group_demo() -> TokenGroup:
+    """Create a token group while letting the helper synthesize a mask."""
+    tokens = jnp.ones((2, 3, 4))
+    return TokenGroup.create(tokens)
+
+
+def concatenate_demo() -> TokenGroup:
+    """Concatenate two groups with different mask patterns."""
+    g1 = TokenGroup.create(jnp.zeros((1, 2, 4)), jnp.array([[1, 0]]))
+    g2 = TokenGroup.create(jnp.ones((1, 3, 4)), jnp.array([[1, 1, 0]]))
+    return TokenGroup.concatenate([g1, g2])
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("create", create_group_demo().mask.shape)
+    print("concat", concatenate_demo().tokens.shape)

--- a/examples/model/components/ex_block_transformer.py
+++ b/examples/model/components/ex_block_transformer.py
@@ -1,0 +1,116 @@
+"""Block-transformer walkthrough guided by :mod:`tests.model.components.test_block_transformer`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from crossformer.model.components.block_transformer import (
+    AttentionRule,
+    BlockTransformer,
+    PrefixGroup,
+    TimestepGroup,
+    TokenMetadata,
+)
+
+
+def _make_groups(batch_size: int = 2, horizon: int = 3, embed_dim: int = 8):
+    """Build prefix and timestep token groups with causal attention defaults."""
+    prefix_tokens = jnp.ones((batch_size, 1, embed_dim))
+    prefix_group = PrefixGroup(
+        tokens=prefix_tokens,
+        mask=jnp.ones((batch_size, 1), dtype=bool),
+        pos_enc=jnp.zeros_like(prefix_tokens),
+        name="task",
+        attention_rules={"task": AttentionRule.CAUSAL},
+    )
+    timestep_tokens = jnp.ones((batch_size, horizon, 2, embed_dim))
+    timestep_group = TimestepGroup(
+        tokens=timestep_tokens,
+        mask=jnp.ones((batch_size, horizon, 2), dtype=bool),
+        pos_enc=jnp.zeros_like(timestep_tokens),
+        name="obs",
+        attention_rules={"task": AttentionRule.CAUSAL, "obs": AttentionRule.CAUSAL},
+    )
+    return [prefix_group], [timestep_group]
+
+
+def metadata_rules_demo() -> dict[str, bool]:
+    """Check directed attention decisions between prefix and timestep metadata."""
+    prefix_groups, timestep_groups = _make_groups(batch_size=1, horizon=2, embed_dim=4)
+    prefix_meta = TokenMetadata.create(prefix_groups[0], timestep=-1)
+    timestep_now = TokenMetadata.create(timestep_groups[0], timestep=1)
+    timestep_past = TokenMetadata.create(timestep_groups[0], timestep=0)
+    return {
+        "prefix_to_prefix": prefix_meta.should_attend_to(prefix_meta),
+        "prefix_to_now": prefix_meta.should_attend_to(timestep_now),
+        "now_to_prefix": timestep_now.should_attend_to(prefix_meta),
+        "now_to_past": timestep_now.should_attend_to(timestep_past),
+        "past_to_now": timestep_past.should_attend_to(timestep_now),
+    }
+
+
+def block_roundtrip_demo() -> dict[str, tuple[int, ...]]:
+    """Run the transformer and confirm the split/merge keeps shapes intact."""
+    prefix_groups, timestep_groups = _make_groups()
+    block = BlockTransformer(
+        transformer_kwargs=dict(
+            num_layers=1,
+            mlp_dim=16,
+            num_attention_heads=2,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            repeat_pos_enc=False,
+        )
+    )
+    params = block.init(jax.random.PRNGKey(0), prefix_groups, timestep_groups, train=False)
+    prefix_out, timestep_out = block.apply(params, prefix_groups, timestep_groups, train=False)
+    tokens, _ = block.assemble_input_tokens(prefix_groups, timestep_groups)
+    rebuilt_prefix, rebuilt_timestep = block.split_output_tokens(tokens, prefix_groups, timestep_groups)
+    return {
+        "prefix_out": prefix_out[0].tokens.shape,
+        "timestep_out": timestep_out[0].tokens.shape,
+        "rebuilt_prefix": rebuilt_prefix[0].tokens.shape,
+        "rebuilt_timestep": rebuilt_timestep[0].tokens.shape,
+    }
+
+
+def attention_mask_demo() -> np.ndarray:
+    """Generate the dense attention mask used by the block transformer."""
+    prefix_groups, timestep_groups = _make_groups(batch_size=1, horizon=2, embed_dim=4)
+    block = BlockTransformer(transformer_kwargs=dict(num_layers=1, mlp_dim=8, num_attention_heads=2))
+    mask = block.generate_attention_mask(prefix_groups, timestep_groups)
+    return np.array(mask[0, 0])
+
+
+def pad_attention_mask_demo() -> np.ndarray:
+    """Blend causal and padding masks into a single attention tensor."""
+    prefix_groups, timestep_groups = _make_groups(batch_size=1, horizon=2, embed_dim=2)
+    timestep_groups[0] = timestep_groups[0].replace(mask=jnp.array([[[True, False], [True, True]]]))
+    block = BlockTransformer(transformer_kwargs=dict(num_layers=1, mlp_dim=8, num_attention_heads=2))
+    generated = block.generate_pad_attention_mask(prefix_groups, timestep_groups)
+    return np.array(generated[0, 0])
+
+
+def causality_check_demo() -> bool:
+    """Verify that relaxing causal rules triggers the internal assertion."""
+    prefix_groups, timestep_groups = _make_groups(batch_size=1, horizon=1)
+    timestep_groups[0] = timestep_groups[0].replace(
+        attention_rules={"task": AttentionRule.ALL, "obs": AttentionRule.ALL}
+    )
+    block = BlockTransformer(transformer_kwargs=dict(num_layers=1, mlp_dim=8, num_attention_heads=2))
+    try:
+        block.verify_causality(prefix_groups, timestep_groups)
+    except AssertionError:
+        return True
+    return False
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("metadata", metadata_rules_demo())
+    shapes = block_roundtrip_demo()
+    print("roundtrip", shapes)
+    print("attn mask", attention_mask_demo().shape)
+    print("pad mask", pad_attention_mask_demo().shape)
+    print("causality guard", causality_check_demo())

--- a/examples/model/components/ex_diffusion.py
+++ b/examples/model/components/ex_diffusion.py
@@ -1,0 +1,131 @@
+"""Diffusion module cookbook aligned with :mod:`tests.model.components.test_diffusion`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from crossformer.model.components.diffusion import (
+    FourierFeatures,
+    MLP,
+    MLPResNet,
+    MLPResNetBlock,
+    ScoreActor,
+    cosine_beta_schedule,
+    create_diffusion_model,
+)
+
+
+def beta_schedule_demo() -> jnp.ndarray:
+    """Return a cosine beta schedule for a small number of timesteps."""
+    return cosine_beta_schedule(10)
+
+
+def fourier_features_demo() -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Contrast learnable and fixed Fourier feature projections."""
+    inputs = jnp.ones((2, 1))
+    learnable = FourierFeatures(output_size=4, learnable=True)
+    params_learnable = learnable.init(jax.random.PRNGKey(0), inputs)
+    outputs_learnable = learnable.apply(params_learnable, inputs)
+
+    fixed = FourierFeatures(output_size=6, learnable=False)
+    params_fixed = fixed.init(jax.random.PRNGKey(1), inputs)
+    outputs_fixed = fixed.apply(params_fixed, inputs)
+    return outputs_learnable, outputs_fixed
+
+
+def mlp_and_resnet_demo() -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Run a feed-forward network and a residual block with dropout RNGs."""
+    mlp = MLP((8, 4), use_layer_norm=True, dropout_rate=0.1, activate_final=True)
+    variables = mlp.init(
+        {"params": jax.random.PRNGKey(2), "dropout": jax.random.PRNGKey(3)},
+        jnp.ones((3, 2)),
+        train=True,
+    )
+    mlp_out = mlp.apply(
+        variables,
+        jnp.ones((3, 2)),
+        train=True,
+        rngs={"dropout": jax.random.PRNGKey(4)},
+    )
+
+    block = MLPResNetBlock(features=4, act=jax.nn.relu, dropout_rate=0.1, use_layer_norm=True)
+    block_vars = block.init(
+        {"params": jax.random.PRNGKey(5), "dropout": jax.random.PRNGKey(6)},
+        jnp.ones((3, 4)),
+        train=True,
+    )
+    block_out = block.apply(
+        block_vars,
+        jnp.ones((3, 4)),
+        train=True,
+        rngs={"dropout": jax.random.PRNGKey(7)},
+    )
+    return mlp_out, block_out
+
+
+def resnet_stack_demo() -> jnp.ndarray:
+    """Stack residual blocks with :class:`MLPResNet`."""
+    resnet = MLPResNet(num_blocks=2, out_dim=5, hidden_dim=16, dropout_rate=0.0, use_layer_norm=True)
+    vars_resnet = resnet.init(jax.random.PRNGKey(8), jnp.ones((2, 4)), train=False)
+    return resnet.apply(vars_resnet, jnp.ones((2, 4)), train=False)
+
+
+def score_actor_demo() -> jnp.ndarray:
+    """Combine Fourier features, conditioning MLPs, and a reverse network."""
+    module = ScoreActor(
+        time_preprocess=FourierFeatures(output_size=4),
+        cond_encoder=MLP((8, 4)),
+        reverse_network=MLPResNet(num_blocks=1, out_dim=3, hidden_dim=8),
+    )
+    variables = module.init(
+        jax.random.PRNGKey(9),
+        obs_enc=jnp.ones((2, 3)),
+        actions=jnp.ones((2, 3)),
+        time=jnp.ones((2, 1)),
+        train=False,
+    )
+    return module.apply(
+        variables,
+        obs_enc=jnp.ones((2, 3)),
+        actions=jnp.ones((2, 3)),
+        time=jnp.ones((2, 1)),
+        train=True,
+    )
+
+
+def diffusion_model_demo() -> jnp.ndarray:
+    """Instantiate the bundled diffusion policy model."""
+    model = create_diffusion_model(
+        out_dim=4,
+        time_dim=4,
+        num_blocks=1,
+        dropout_rate=0.0,
+        hidden_dim=8,
+        use_layer_norm=True,
+    )
+    variables = model.init(
+        jax.random.PRNGKey(10),
+        obs_enc=jnp.ones((2, 4)),
+        actions=jnp.ones((2, 4)),
+        time=jnp.ones((2, 1)),
+        train=False,
+    )
+    return model.apply(
+        variables,
+        obs_enc=jnp.ones((2, 4)),
+        actions=jnp.ones((2, 4)),
+        time=jnp.ones((2, 1)),
+        train=True,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("betas", beta_schedule_demo().shape)
+    learnable, fixed = fourier_features_demo()
+    print("fourier", learnable.shape, fixed.shape)
+    mlp_out, block_out = mlp_and_resnet_demo()
+    print("mlp", mlp_out.shape, "block", block_out.shape)
+    print("resnet", resnet_stack_demo().shape)
+    print("score actor", score_actor_demo().shape)
+    print("diffusion", diffusion_model_demo().shape)

--- a/examples/model/components/ex_film_conditioning_layer.py
+++ b/examples/model/components/ex_film_conditioning_layer.py
@@ -1,0 +1,24 @@
+"""FILM conditioning example matching :mod:`tests.model.components.test_film_conditioning_layer`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from crossformer.model.components.film_conditioning_layer import FilmConditioning
+
+
+def film_demo() -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Apply feature-wise affine modulation with and without conditioning."""
+    conv = jnp.ones((2, 4, 4, 3))
+    conditioning = jnp.array([[1.0, -1.0], [-0.5, 0.5]])
+    module = FilmConditioning()
+    variables = module.init(jax.random.PRNGKey(0), conv, conditioning)
+    shifted = module.apply(variables, conv, conditioning)
+    baseline = module.apply(variables, conv, jnp.zeros_like(conditioning))
+    return shifted, baseline
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    shifted, baseline = film_demo()
+    print("shifted", shifted.shape, "baseline", baseline.shape)

--- a/examples/model/components/ex_tokenizers.py
+++ b/examples/model/components/ex_tokenizers.py
@@ -1,0 +1,144 @@
+"""Tokenizer usage notes referencing :mod:`tests.model.components.test_tokenizers`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from crossformer.model.components.base import TokenGroup
+from crossformer.model.components.tokenizers import (
+    BinTokenizer,
+    ImageTokenizer,
+    LanguageTokenizer,
+    LowdimObsTokenizer,
+    TokenLearner,
+    generate_proper_pad_mask,
+    regex_filter,
+    regex_match,
+)
+from crossformer.model.components.vit_encoders import PatchEncoder
+from crossformer.utils.spec import ModuleSpec
+
+
+def pad_mask_demo() -> jnp.ndarray:
+    """Combine per-modality pad masks into a single broadcastable array."""
+    tokens = jnp.zeros((2, 3, 4, 2))
+    pad_mask_dict = {
+        "a": jnp.array([[True, False, True], [False, True, True]]),
+        "b": jnp.zeros((2, 3), dtype=bool),
+    }
+    return generate_proper_pad_mask(tokens, pad_mask_dict, ("a", "b"))
+
+
+def token_learner_demo() -> jnp.ndarray:
+    """Learn a compact set of visual tokens with dropout disabled."""
+    module = TokenLearner(num_tokens=2)
+    inputs = jnp.ones((1, 4, 8))
+    variables = module.init(
+        {"params": jax.random.PRNGKey(0), "dropout": jax.random.PRNGKey(1)},
+        inputs,
+        train=True,
+    )
+    return module.apply(variables, inputs, train=False)
+
+
+def regex_helper_demo(pattern: str) -> tuple[bool, list[str]]:
+    """Check whether token keys match a regex and filter accordingly."""
+    keys = ["image_primary", "language_instruction"]
+    return regex_match((pattern,), keys[0]), regex_filter((pattern,), keys)
+
+
+def _make_image_tokenizer(**overrides) -> ImageTokenizer:
+    spec = ModuleSpec.create(PatchEncoder, patch_size=1, num_features=8)
+    return ImageTokenizer(encoder=spec, **overrides)
+
+
+def image_tokenizer_demo() -> TokenGroup:
+    """Encode image observations into spatial tokens."""
+    tokenizer = _make_image_tokenizer()
+    observations = {
+        "image_primary": jnp.ones((2, 2, 2, 2, 3)),
+        "pad_mask_dict": {"image_primary": jnp.array([[True, False], [True, True]])},
+    }
+    tasks: dict[str, jnp.ndarray] = {}
+    variables = tokenizer.init(
+        {"params": jax.random.PRNGKey(0), "dropout": jax.random.PRNGKey(1)},
+        observations,
+        tasks,
+        train=False,
+    )
+    return tokenizer.apply(variables, observations, tasks, train=False)
+
+
+def image_tokenizer_with_token_learner_demo() -> TokenGroup:
+    """Chain token learner pooling after convolutional encoding."""
+    tokenizer = _make_image_tokenizer(use_token_learner=True, num_tokens=3)
+    observations = {
+        "image_primary": jnp.ones((1, 2, 2, 2, 3)),
+        "pad_mask_dict": {"image_primary": jnp.array([[True, True]])},
+    }
+    tasks: dict[str, jnp.ndarray] = {}
+    variables = tokenizer.init(
+        {"params": jax.random.PRNGKey(2), "dropout": jax.random.PRNGKey(3)},
+        observations,
+        tasks,
+        train=True,
+    )
+    return tokenizer.apply(
+        variables,
+        observations,
+        tasks,
+        train=True,
+        rngs={"dropout": jax.random.PRNGKey(4)},
+    )
+
+
+def language_tokenizer_demo() -> TokenGroup:
+    """Turn tokenized language instructions into padded token groups."""
+    tokenizer = LanguageTokenizer(proper_pad_mask=True)
+    tasks = {
+        "language_instruction": jnp.array([[[[1]], [[2]], [[3]]]]),
+        "pad_mask_dict": {"language_instruction": jnp.array([[True, True, False]])},
+    }
+    observations: dict[str, jnp.ndarray] = {}
+    return tokenizer(observations, tasks, train=False)
+
+
+def bin_tokenizer_demo() -> jnp.ndarray:
+    """Discretize scalar inputs and decode them back to the original scale."""
+    tokenizer = BinTokenizer(n_bins=4, bin_type="uniform", low=0.0, high=1.0)
+    inputs = jnp.array([[0.1, 0.5, 0.9]])
+    variables = tokenizer.init(jax.random.PRNGKey(5), inputs)
+    tokens = tokenizer.apply(variables, inputs)
+    decoded = tokenizer.apply(variables, tokens, method=tokenizer.decode)
+    return decoded
+
+
+def lowdim_tokenizer_demo() -> tuple[TokenGroup, TokenGroup]:
+    """Compare continuous and discretized encodings of low-dimensional observations."""
+    observations = {"state": jnp.ones((1, 2, 3))}
+    tasks: dict[str, jnp.ndarray] = {}
+    tokenizer_cont = LowdimObsTokenizer(obs_keys=("state",), discretize=False)
+    vars_cont = tokenizer_cont.init(
+        {"params": jax.random.PRNGKey(6)}, observations, tasks, train=False
+    )
+    group_cont = tokenizer_cont.apply(vars_cont, observations, tasks, train=False)
+
+    tokenizer_disc = LowdimObsTokenizer(obs_keys=("state",), discretize=True, n_bins=8)
+    vars_disc = tokenizer_disc.init(
+        {"params": jax.random.PRNGKey(7)}, observations, tasks, train=False
+    )
+    group_disc = tokenizer_disc.apply(vars_disc, observations, tasks, train=False)
+    return group_cont, group_disc
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("pad_mask", pad_mask_demo().shape)
+    print("token_learner", token_learner_demo().shape)
+    print("regex", regex_helper_demo("image_.*"))
+    print("image", image_tokenizer_demo().tokens.shape)
+    print("image+learner", image_tokenizer_with_token_learner_demo().tokens.shape)
+    print("language", language_tokenizer_demo().tokens.shape)
+    print("bin", bin_tokenizer_demo().shape)
+    cont, disc = lowdim_tokenizer_demo()
+    print("lowdim cont", cont.tokens.shape, "disc", disc.tokens.shape)

--- a/examples/model/components/ex_transformer.py
+++ b/examples/model/components/ex_transformer.py
@@ -1,0 +1,102 @@
+"""Transformer component examples aligned with :mod:`tests.model.components.test_transformer`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from crossformer.model.components.base import TokenGroup
+from crossformer.model.components.transformer import (
+    AddPositionEmbs,
+    Encoder1DBlock,
+    MAPHead,
+    MlpBlock,
+    Transformer,
+    common_transformer_sizes,
+)
+
+
+def positional_embedding_demo() -> jnp.ndarray:
+    """Apply learned position biases to a flat token grid."""
+    module = AddPositionEmbs(
+        posemb_init=lambda key, shape, dtype=jnp.float32: jnp.ones(shape, dtype)
+    )
+    inputs = jnp.zeros((2, 3, 4))
+    variables = module.init(jax.random.PRNGKey(0), inputs)
+    return module.apply(variables, inputs)
+
+
+def mlp_block_demo() -> jnp.ndarray:
+    """Run the feed-forward sub-block with deterministic dropout."""
+    block = MlpBlock(mlp_dim=8, dropout_rate=0.0)
+    variables = block.init(jax.random.PRNGKey(1), jnp.ones((2, 4)), deterministic=True)
+    return block.apply(variables, jnp.ones((2, 4)), deterministic=True)
+
+
+def map_head_demo() -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Pool a :class:`TokenGroup` and a raw array with the same parameters."""
+    tokens = jnp.ones((2, 5, 6))
+    mask = jnp.array([[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]], dtype=bool)
+    group = TokenGroup(tokens=tokens, mask=mask)
+
+    head = MAPHead(num_heads=2, num_readouts=2)
+    variables = head.init(jax.random.PRNGKey(2), group, train=False)
+    pooled_group = head.apply(variables, group, train=False)
+    pooled_array = head.apply(variables, tokens, train=False)
+    return pooled_group, pooled_array
+
+
+def encoder_block_demo() -> jnp.ndarray:
+    """Forward a causal encoder block with explicit attention masks."""
+    block = Encoder1DBlock(
+        mlp_dim=8,
+        num_heads=2,
+        dropout_rate=0.0,
+        attention_dropout_rate=0.0,
+        repeat_pos_enc=True,
+    )
+    x = jnp.ones((2, 4, 6))
+    pos_enc = jnp.linspace(0, 1, 2 * 4 * 6).reshape(2, 4, 6)
+    attn_mask = jnp.ones((2, 1, 4, 4))
+    variables = block.init(jax.random.PRNGKey(3), x, pos_enc, attn_mask, deterministic=True)
+    return block.apply(variables, x, pos_enc, attn_mask, deterministic=True)
+
+
+def transformer_stack_demo() -> jnp.ndarray:
+    """Stack multiple encoder blocks using :class:`Transformer`."""
+    transformer = Transformer(
+        num_layers=2,
+        mlp_dim=16,
+        num_attention_heads=2,
+        dropout_rate=0.0,
+        attention_dropout_rate=0.0,
+        repeat_pos_enc=False,
+    )
+    x = jnp.ones((1, 4, 8))
+    pos_enc = jnp.zeros_like(x)
+    attn_mask = jnp.ones((1, 1, 4, 4))
+    variables = transformer.init(jax.random.PRNGKey(4), x, pos_enc, attn_mask, train=False)
+    return transformer.apply(variables, x, pos_enc, attn_mask, train=False)
+
+
+def preset_lookup_demo() -> dict[str, int | tuple[int, ...]]:
+    """Inspect bundled configuration presets for convenience sizing."""
+    dim, config = common_transformer_sizes("vit_b")
+    fallback_dim, fallback_cfg = common_transformer_sizes("dummy")
+    return {
+        "vit_b_dim": dim,
+        "vit_b_layers": config["num_layers"],
+        "fallback_dim": fallback_dim,
+        "fallback_layers": fallback_cfg["num_layers"],
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("positional", positional_embedding_demo().shape)
+    print("mlp", mlp_block_demo().shape)
+    pooled_group, pooled_array = map_head_demo()
+    print("map_head group", pooled_group.shape)
+    print("map_head array", pooled_array.shape)
+    print("encoder", encoder_block_demo().shape)
+    print("transformer", transformer_stack_demo().shape)
+    print("presets", preset_lookup_demo())

--- a/examples/model/components/ex_vit_encoders.py
+++ b/examples/model/components/ex_vit_encoders.py
@@ -1,0 +1,145 @@
+"""Vision encoder cookbook echoing :mod:`tests.model.components.test_vit_encoders`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+
+from crossformer.model.components.vit_encoders import (
+    PatchEncoder,
+    ResNet26,
+    ResNet26FILM,
+    ResNetStage,
+    ResidualUnit,
+    SmallStem,
+    SmallStem16,
+    SmallStem32,
+    StdConv,
+    ViTResnet,
+    normalize_images,
+    vit_encoder_configs,
+    weight_standardize,
+)
+
+
+def normalization_demo() -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Compare default and ImageNet normalization strategies."""
+    default = normalize_images(jnp.array([[[[0], [255]]]], dtype=jnp.uint8))
+    imagenet_input = jnp.ones((1, 2, 2, 6), dtype=jnp.uint8)
+    imagenet = normalize_images(imagenet_input, img_norm_type="imagenet")
+    return default, imagenet
+
+
+def weight_standardize_demo() -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Standardize convolution kernels and report mean/std."""
+    kernel = jnp.arange(3 * 3 * 2 * 4, dtype=jnp.float32).reshape(3, 3, 2, 4)
+    standardized = weight_standardize(kernel, axis=[0, 1, 2], eps=1e-5)
+    mean = standardized.mean(axis=(0, 1, 2))
+    std = standardized.std(axis=(0, 1, 2))
+    return mean, std
+
+
+def stdconv_demo() -> jnp.ndarray:
+    """Run :class:`StdConv` and compare with a manual reference convolution."""
+    conv = StdConv(features=2, kernel_size=(3, 3))
+    inputs = jnp.ones((1, 5, 5, 2))
+    variables = conv.init(jax.random.PRNGKey(0), inputs)
+    outputs = conv.apply(variables, inputs)
+    kernel = variables["params"]["kernel"]
+    standardized_kernel = weight_standardize(kernel, axis=[0, 1, 2], eps=1e-5)
+    ref_conv = nn.Conv(features=2, kernel_size=(3, 3))
+    ref_params = {"params": {"kernel": standardized_kernel, "bias": variables["params"].get("bias", jnp.zeros((2,)))}}
+    ref_outputs = ref_conv.apply(ref_params, inputs)
+    return outputs - ref_outputs
+
+
+def film_patch_and_stem_demo() -> tuple[int, int]:
+    """Encode images with conditional FiLM modules and report channel counts."""
+    patch = PatchEncoder(use_film=True, patch_size=2, num_features=4)
+    obs = jnp.ones((1, 16, 16, 3))
+    cond = jnp.ones((1, 2))
+    patch_vars = patch.init(jax.random.PRNGKey(1), obs, train=False, cond_var=cond)
+    patch_out = patch.apply(patch_vars, obs, train=False, cond_var=cond)
+
+    stem = SmallStem(
+        use_film=True,
+        patch_size=16,
+        features=(32, 64),
+        strides=(2, 2),
+        kernel_sizes=(3, 3),
+        padding=(1, 1),
+    )
+    stem_vars = stem.init(jax.random.PRNGKey(2), obs, train=False, cond_var=cond)
+    stem_out = stem.apply(stem_vars, obs, train=False, cond_var=cond)
+    return patch_out.shape[-1], stem_out.shape[-1]
+
+
+def residual_stack_demo() -> tuple[int, int]:
+    """Pass data through a residual unit and a short ResNet stage."""
+    unit = ResidualUnit(features=32)
+    x = jnp.ones((1, 4, 4, 128))
+    vars_unit = unit.init(jax.random.PRNGKey(3), x)
+    out_unit = unit.apply(vars_unit, x)
+
+    stage = ResNetStage(block_size=1, nout=32, first_stride=(1, 1))
+    vars_stage = stage.init(jax.random.PRNGKey(4), out_unit)
+    out_stage = stage.apply(vars_stage, out_unit)
+    return out_unit.shape[-1], out_stage.shape[-1]
+
+
+def vit_resnet_variants_demo() -> tuple[int, int, int]:
+    """Compare ViT-ResNet hybrids with and without FiLM conditioning."""
+    obs = jnp.ones((1, 8, 8, 3))
+    vit = ViTResnet(use_film=False, num_layers=(1, 1))
+    vit_vars = vit.init(jax.random.PRNGKey(5), obs, train=False)
+    vit_out = vit.apply(vit_vars, obs, train=False)
+
+    cond = jnp.ones((1, 4))
+    film = ResNet26FILM()
+    film_vars = film.init(jax.random.PRNGKey(6), obs, train=False, cond_var=cond)
+    film_out = film.apply(film_vars, obs, train=False, cond_var=cond)
+
+    resnet26 = ResNet26()
+    resnet_vars = resnet26.init(jax.random.PRNGKey(7), obs, train=False)
+    resnet_out = resnet26.apply(resnet_vars, obs, train=False)
+    return vit_out.ndim, film_out.shape[0], resnet_out.shape[0]
+
+
+def small_stem_variants_demo() -> tuple[int, int]:
+    """Show the default patch sizes baked into SmallStem16/32 variants."""
+    obs = jnp.ones((1, 8, 8, 3))
+    stem16 = SmallStem16()
+    vars16 = stem16.init(jax.random.PRNGKey(8), obs, train=False)
+    _ = stem16.apply(vars16, obs, train=False)
+    stem32 = SmallStem32()
+    vars32 = stem32.init(jax.random.PRNGKey(9), obs, train=False)
+    _ = stem32.apply(vars32, obs, train=False)
+    return stem16.patch_size, stem32.patch_size
+
+
+def config_catalog_demo() -> dict[str, type[nn.Module]]:
+    """Materialize the preset factory to emphasize extensibility."""
+    catalog = {}
+    inputs = jnp.ones((1, 4, 4, 3))
+    cond = jnp.ones((1, 4))
+    for name, factory in vit_encoder_configs.items():
+        module = factory()
+        kwargs = dict(train=False)
+        if getattr(module, "use_film", False):
+            kwargs["cond_var"] = cond
+        variables = module.init(jax.random.PRNGKey(hash(name) & 0xFFFF), inputs, **kwargs)
+        _ = module.apply(variables, inputs, **kwargs)
+        catalog[name] = type(module)
+    return catalog
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    print("normalize", [arr.shape for arr in normalization_demo()])
+    print("weight standardize", weight_standardize_demo())
+    print("stdconv diff", jnp.abs(stdconv_demo()).max())
+    print("film patch/stem", film_patch_and_stem_demo())
+    print("residual stage", residual_stack_demo())
+    print("variants", vit_resnet_variants_demo())
+    print("stem variants", small_stem_variants_demo())
+    print("catalog", list(config_catalog_demo().keys())[:3], "...")


### PR DESCRIPTION
## Summary
- add a new examples package with walkthroughs mirroring each test module
- document model component usage, including action heads, transformers, tokenizers, and diffusion stacks
- provide Grain data pipeline examples that cover metadata, transforms, runtime options, builders, and pipelines

## Testing
- python -m compileall examples

------
https://chatgpt.com/codex/tasks/task_e_68d47d86dff48329b48f156cd08d826d