### PR TITLE
Add tests for CN configuration components

### DIFF
--- a/crossformer/cn/device.py
+++ b/crossformer/cn/device.py
@@ -51,4 +51,4 @@ class Slurm(Cluster):
     def __post_init__(self):
         if self.nodelist:
             self.nodelist = self.parse_nodelist(self.nodelist)
-             assert len(self.nodelist) == self.num_nodes, "num_nodes != len(nodelist)"
+            assert len(self.nodelist) == self.num_nodes, "num_nodes != len(nodelist)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,280 @@
+import importlib
 import sys
+import types
+from enum import Enum, IntEnum
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+def _ensure_module(name: str, module: types.ModuleType) -> None:
+    sys.modules[name] = module
+
+
+def _stub_jax() -> None:
+    try:
+        importlib.import_module("jax")
+    except Exception:
+        module = types.ModuleType("jax")
+        module.process_count = lambda: 1
+        module.device_count = lambda: 1
+        _ensure_module("jax", module)
+
+
+def _stub_tyro() -> None:
+    try:
+        importlib.import_module("tyro")
+    except Exception:
+        module = types.ModuleType("tyro")
+        module.MISSING = object()
+        extras = types.ModuleType("tyro.extras")
+        extras.overridable_config_cli = lambda mapping: mapping
+        module.extras = extras
+        module.cli = lambda cfg=None: cfg
+        _ensure_module("tyro", module)
+        _ensure_module("tyro.extras", extras)
+
+
+def _stub_rich() -> None:
+    try:
+        importlib.import_module("rich")
+    except Exception:
+        module = types.ModuleType("rich")
+        pretty = types.ModuleType("rich.pretty")
+
+        def _noop(*args, **kwargs):
+            return None
+
+        module.print = _noop
+        pretty.pprint = _noop
+        module.pretty = pretty
+        _ensure_module("rich", module)
+        _ensure_module("rich.pretty", pretty)
+
+
+def _stub_flax() -> None:
+    try:
+        importlib.import_module("flax.traverse_util")
+    except Exception:
+        sys.modules.pop("flax", None)
+        sys.modules.pop("flax.traverse_util", None)
+        flax_module = types.ModuleType("flax")
+        traverse_util = types.ModuleType("flax.traverse_util")
+
+        def flatten_dict(tree, keep_empty_nodes: bool = False):
+            result: dict[tuple[str, ...], object] = {}
+
+            def _flatten(prefix, value):
+                if isinstance(value, dict):
+                    if not value and keep_empty_nodes:
+                        result[tuple(prefix)] = value
+                    for key, val in value.items():
+                        _flatten(prefix + [key], val)
+                else:
+                    result[tuple(prefix)] = value
+
+            _flatten([], tree)
+            return result
+
+        traverse_util.flatten_dict = flatten_dict  # type: ignore[attr-defined]
+        flax_module.traverse_util = traverse_util  # type: ignore[attr-defined]
+        _ensure_module("flax", flax_module)
+        _ensure_module("flax.traverse_util", traverse_util)
+
+
+def _stub_six() -> None:
+    try:
+        importlib.import_module("six")
+    except Exception:
+        module = types.ModuleType("six")
+        module.u = lambda s: s
+        _ensure_module("six", module)
+
+
+def _stub_omegaconf() -> None:
+    try:
+        importlib.import_module("omegaconf")
+    except Exception:
+        sys.modules.pop("omegaconf", None)
+        module = types.ModuleType("omegaconf")
+
+        class _OmegaConf:
+            @staticmethod
+            def create(data):
+                return data
+
+            @staticmethod
+            def to_container(data):
+                return data
+
+            @staticmethod
+            def to_object(data):
+                return data
+
+        module.OmegaConf = _OmegaConf
+        _ensure_module("omegaconf", module)
+
+
+def _stub_data_utils() -> None:
+    try:
+        importlib.import_module("crossformer.data.utils.data_utils")
+    except Exception:
+        sys.modules.pop("crossformer.data.utils.data_utils", None)
+        module = types.ModuleType("crossformer.data.utils.data_utils")
+
+        class NormalizationType(Enum):
+            NORMAL = "normal"
+
+        module.NormalizationType = NormalizationType
+        _ensure_module("crossformer.data.utils.data_utils", module)
+
+
+def _stub_data_oxe() -> None:
+    try:
+        importlib.import_module("crossformer.data.oxe")
+    except Exception:
+        for name in [
+            "crossformer.data.oxe",
+            "crossformer.data.oxe.oxe_dataset_configs",
+            "crossformer.data.oxe.oxe_dataset_mixes",
+        ]:
+            sys.modules.pop(name, None)
+
+        oxe_configs = types.ModuleType("crossformer.data.oxe.oxe_dataset_configs")
+
+        class ActionDim(IntEnum):
+            SINGLE = 7
+            BIMANUAL = 14
+            MANO = 63
+            DMANO_6 = 6
+            DMANO_7 = 7
+            DMANO_35 = 35
+            DMANO_51 = 51
+            DMANO_52 = 52
+            QUADRUPED = 12
+
+        class ProprioDim(IntEnum):
+            POS_EULER = 7
+            POS_QUAT = 8
+            JOINT = 8
+            BIMANUAL = 14
+            QUADRUPED = 12
+            MANO = 8
+
+        oxe_configs.ActionDim = ActionDim
+        oxe_configs.ProprioDim = ProprioDim
+        _ensure_module("crossformer.data.oxe.oxe_dataset_configs", oxe_configs)
+
+        oxe_mixes = types.ModuleType("crossformer.data.oxe.oxe_dataset_mixes")
+        HEAD_TO_DATASET = {
+            "single": ["xgym_stack_single"],
+            "bimanual": ["xgym_bimanual"],
+            "mano": ["xgym_mano"],
+            "quadruped": ["xgym_quadruped"],
+        }
+        OXE_NAMED_MIXES = {
+            "xgym_stack_single": [("xgym_stack_single", 1.0)],
+            "xgym_duck_single": [("xgym_duck_single", 1.0)],
+            "xgym_lift_single": [("xgym_lift_single", 1.0)],
+        }
+        oxe_mixes.HEAD_TO_DATASET = HEAD_TO_DATASET
+        oxe_mixes.OXE_NAMED_MIXES = OXE_NAMED_MIXES
+        _ensure_module("crossformer.data.oxe.oxe_dataset_mixes", oxe_mixes)
+
+        oxe_module = types.ModuleType("crossformer.data.oxe")
+        oxe_module.ActionDim = ActionDim
+        oxe_module.HEAD_TO_DATASET = HEAD_TO_DATASET
+        oxe_module.OXE_NAMED_MIXES = OXE_NAMED_MIXES
+        _ensure_module("crossformer.data.oxe", oxe_module)
+
+
+def _stub_data_dataset() -> None:
+    try:
+        importlib.import_module("crossformer.data.dataset")
+    except Exception:
+        sys.modules.pop("crossformer.data.dataset", None)
+        module = types.ModuleType("crossformer.data.dataset")
+
+        def make_interleaved_dataset(*args, **kwargs):
+            return {"kind": "interleaved", "args": args, "kwargs": kwargs}
+
+        def make_single_dataset(*args, **kwargs):
+            return {"kind": "single", "args": args, "kwargs": kwargs}
+
+        module.make_interleaved_dataset = make_interleaved_dataset
+        module.make_single_dataset = make_single_dataset
+        _ensure_module("crossformer.data.dataset", module)
+
+
+def _stub_action_heads() -> None:
+    try:
+        importlib.import_module("crossformer.model.components.action_heads")
+    except Exception:
+        sys.modules.pop("crossformer.model.components.action_heads", None)
+        module = types.ModuleType("crossformer.model.components.action_heads")
+
+        class ActionHead:  # minimal stub for ModuleSpec
+            pass
+
+        class L1ActionHead(ActionHead):
+            pass
+
+        class DiffusionActionHead(ActionHead):
+            pass
+
+        module.ActionHead = ActionHead
+        module.L1ActionHead = L1ActionHead
+        module.DiffusionActionHead = DiffusionActionHead
+        _ensure_module("crossformer.model.components.action_heads", module)
+
+
+def _stub_tokenizers() -> None:
+    try:
+        importlib.import_module("crossformer.model.components.tokenizers")
+    except Exception:
+        sys.modules.pop("crossformer.model.components.tokenizers", None)
+        module = types.ModuleType("crossformer.model.components.tokenizers")
+
+        class ImageTokenizer:  # pragma: no cover - stub
+            pass
+
+        class LowdimObsTokenizer:  # pragma: no cover - stub
+            pass
+
+        module.ImageTokenizer = ImageTokenizer
+        module.LowdimObsTokenizer = LowdimObsTokenizer
+        _ensure_module("crossformer.model.components.tokenizers", module)
+
+
+def _stub_vit_encoders() -> None:
+    try:
+        importlib.import_module("crossformer.model.components.vit_encoders")
+    except Exception:
+        sys.modules.pop("crossformer.model.components.vit_encoders", None)
+        module = types.ModuleType("crossformer.model.components.vit_encoders")
+
+        class ResNet26:  # pragma: no cover - stub
+            pass
+
+        class ResNet26FILM:  # pragma: no cover - stub
+            pass
+
+        module.ResNet26 = ResNet26
+        module.ResNet26FILM = ResNet26FILM
+        _ensure_module("crossformer.model.components.vit_encoders", module)
+
+
+_stub_jax()
+_stub_tyro()
+_stub_rich()
+_stub_flax()
+_stub_six()
+_stub_omegaconf()
+_stub_data_utils()
+_stub_data_oxe()
+_stub_data_dataset()
+_stub_action_heads()
+_stub_tokenizers()
+_stub_vit_encoders()

--- a/tests/test_cn_configs.py
+++ b/tests/test_cn_configs.py
@@ -1,0 +1,206 @@
+from dataclasses import dataclass
+
+import pytest
+
+from crossformer.cn.base import CN, default
+from crossformer.cn.dataset.mix import DataSource, MultiDataSource, TFDS
+from crossformer.cn.dataset.types import Head
+from crossformer.cn.dataset.dataset import Loader, Dataset
+from crossformer.cn.dataset.transform import KeepProb, Modality, Transform
+from crossformer.cn.dataset.action import DataPrep
+from crossformer.cn.device import Slurm
+from crossformer.cn.optim import Cosine, LearningRate, Optimizer
+from crossformer.cn.wab import Wandb
+from crossformer.cn.eval import Eval
+from crossformer.cn import HeadFactory, ModelFactory, ModuleE, Train
+from crossformer.cn.rollout import Rollout
+
+import jax
+
+
+def dummy_standardize_fn():
+    return "standardized"
+
+
+@dataclass
+class _Child(CN):
+    value: int = 1
+
+
+@dataclass
+class _Parent(CN):
+    child: _Child = _Child().field()
+    numbers: list[int] = default([1, 2])
+    mapping: dict[str, float] = default({"a": 0.1})
+    keep: KeepProb = KeepProb.HIGH
+
+
+def test_cn_base_serialization_and_update():
+    parent = _Parent()
+    serialized = parent.serialize()
+    assert serialized["child"]["value"] == 1
+    assert serialized["numbers"] == [1, 2]
+    assert serialized["mapping"]["a"] == 0.1
+    assert serialized["keep"]["name"] == "HIGH"
+
+    parent.update({"numbers": [3], "child": _Child(value=5)})
+    assert parent.numbers == [3]
+    assert isinstance(parent.child, _Child)
+    assert parent.child.value == 5
+
+
+def test_data_sources_register_and_flatten():
+    ds_name = "unit_test_source"
+    source = TFDS(name=ds_name, head=Head.SINGLE)
+    assert DataSource.REGISTRY[ds_name] is source
+    assert source.flatten() == [(ds_name, 1.0)]
+
+    combo = MultiDataSource(name="unit_test_mix", data=[source], weights=[0.5])
+    assert combo.flatten() == [(ds_name, 0.5)]
+
+    with pytest.raises(AssertionError):
+        MultiDataSource(name="bad_mix", data=[source], weights=[0.2, 0.8])
+
+
+def test_loader_batch_size_respects_process_count(monkeypatch):
+    monkeypatch.setattr(jax, "process_count", lambda: 4)
+    loader = Loader(global_batch_size=32)
+    assert loader.batch_size == 8
+    assert loader.global_batch_size == 32
+
+
+def test_dataset_kwargs_generation():
+    dataset = Dataset()
+    kwargs_list, prep_list = dataset.kwargs_list(oxe_fns={"xgym_stack_single": dummy_standardize_fn})
+
+    assert len(kwargs_list) == len(prep_list) == 1
+    kwargs = kwargs_list[0]
+    prep = prep_list[0]
+
+    assert prep.name == "xgym_stack_single"
+    assert kwargs["name"] == "xgym_stack_single"
+    assert kwargs["language_key"] == "language_instruction"
+    assert kwargs["action_normalization_mask"][-1] is False
+    assert kwargs["standardize_fn"]["name"] == dummy_standardize_fn.__name__
+
+    more_kwargs = dataset.kwargs()
+    assert more_kwargs["batch_size"] == dataset.bs
+    assert more_kwargs["traj_read_threads"] == dataset.loader.threads_traj_read
+
+
+def test_transform_adjusts_keep_image_prob_and_creates_configs():
+    transform = Transform(name="custom", task_cond=Modality.IMG, keep_image_prob=0.0)
+    assert transform.keep_image_prob == 1.0
+
+    frame = transform.frame.create(["primary"])
+    assert frame["resize_size"]["primary"] == transform.frame.resize_size
+    assert "image_augment_kwargs" in frame
+
+    traj = transform.traj.create()
+    assert traj["goal_relabeling_strategy"] == transform.traj.goal_relabeling_strategy.value
+    assert "head_to_dataset" in traj
+
+
+def test_data_prep_create_uses_specification():
+    prep = DataPrep(
+        name="xgym_stack_single",
+        weight=1.0,
+        load_camera_views=["primary"],
+        load_proprio=True,
+        load_language=True,
+    )
+
+    config = prep.create({"xgym_stack_single": dummy_standardize_fn})
+    assert config["name"] == "xgym_stack_single"
+    assert config["proprio_obs_keys"] == {"primary": "proprio"}
+    assert config["language_key"] == "language_instruction"
+    assert config["action_normalization_mask"][-1] is False
+
+
+def test_slurm_parses_environment(monkeypatch):
+    slurm = Slurm(num_nodes=2, nodelist="node[1-2]")
+    assert slurm.nodelist == ["node1", "node2"]
+
+    monkeypatch.setenv("SLURM_JOB_NUM_NODES", "3")
+    monkeypatch.setenv("SLURM_JOB_NODELIST", "gpu[1-3]")
+    from_env = Slurm().from_env()
+    assert from_env.num_nodes == 3
+    assert from_env.nodelist == ["gpu1", "gpu2", "gpu3"]
+
+
+def test_learning_rate_and_optimizer_create():
+    lr = LearningRate(decay_steps=100, first=0.0, peak=0.5, last=0.01)
+    lr_config = lr.create()
+    assert lr_config["init_value"] == 0.0
+    assert lr_config["peak_value"] == 0.5
+    assert lr_config["end_value"] == 0.01
+    assert lr_config["decay_steps"] == 100
+
+    opt = Optimizer(lr=Cosine(decay_steps=50))
+    opt_config = opt.create()
+    assert opt_config["learning_rate"]["decay_steps"] == 50
+    assert "mode" not in opt_config
+
+
+def test_wandb_mode_changes_with_debug():
+    wandb = Wandb()
+    assert wandb.mode(debug=False) == "online"
+    assert wandb.mode(debug=True) == "disabled"
+
+
+def test_eval_create_attaches_datasets():
+    config = Eval(shuffle_buffer=5, nbatch=2).create(["ds"])
+    assert config["datasets"] == ["ds"]
+    assert config["shuffle_buffer"] == 5
+
+
+def test_head_factory_creates_module_spec():
+    head = HeadFactory(name="single", module=ModuleE.L1, horizon=3)
+    spec = head.create()
+    assert spec["kwargs"]["action_horizon"] == 3
+    assert spec["kwargs"]["action_dim"] == head.dim.value
+    assert "diffusion_steps" not in spec["kwargs"]
+
+    diff = HeadFactory(name="bimanual", module=ModuleE.DIFFUSION, horizon=2, steps=5)
+    diff_spec = diff.create()
+    assert diff_spec["kwargs"]["diffusion_steps"] == 5
+
+
+def test_model_factory_builds_selected_heads():
+    factory = ModelFactory(heads=["single", "mano"])
+    factory.single.horizon = 2
+    factory.mano.horizon = 5
+
+    model_config = factory.create()["model"]
+    assert set(model_config["heads"].keys()) == {"single", "mano"}
+    assert factory.max_horizon() == 5
+    assert factory.max_action_dim() == max(
+        factory.single.dim.value, factory.mano.dim.value
+    )
+
+    spec = factory.spec()["model"]
+    assert spec["heads"]["single"] == model_config["heads"]["single"]["module"]
+
+    flat = factory.flatten()
+    assert any(key[:2] == ("model", "heads") for key in flat)
+
+    flat_dict = {
+        ("model", "heads", "single", "module"): "keep",
+        ("model", "heads", "unused", "module"): "drop",
+    }
+    filtered = factory.delete(flat_dict)
+    assert ("model", "heads", "unused", "module") not in filtered
+    assert ("model", "heads", "single", "module") in filtered
+
+
+def test_train_post_init_aligns_components():
+    train = Train()
+    assert train.data.transform.traj.action_horizon == train.model.max_horizon()
+    assert train.data.transform.traj.max_action_dim == train.model.max_action_dim()
+    assert train.optimizer.lr.decay_steps == train.steps
+
+
+def test_rollout_configuration():
+    rollout = Rollout(num_envs=3, use=True)
+    assert rollout.num_envs == 3
+    assert rollout.use is True


### PR DESCRIPTION
## Summary
- stub optional dependencies in test harness so CN modules can be imported without heavyweight packages
- add comprehensive unit tests covering dataset, optimizer, device, eval, and model configuration dataclasses
- fix Slurm post-init assertion indentation to avoid syntax errors during import

## Testing
- pytest tests/test_cn_configs.py

------
https://chatgpt.com/codex/tasks/task_e_68cf53ec74c883298412bf8d9812e4ac