### PR TITLE
Handle empty streams in ArrayRecordBuilder

### DIFF
--- a/tests/grain/arec/test_arec_builder.py
+++ b/tests/grain/arec/test_arec_builder.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+from crossformer.data.grain.arec.arec import ArrayRecordBuilder
+
+
+def test_prepare_empty_stream(tmp_path):
+    builder = ArrayRecordBuilder(
+        name="empty_ds",
+        root=str(tmp_path),
+        version="v0",
+        shard_size=2,
+    )
+
+    builder.prepare(lambda: iter(()))
+
+    meta = builder.meta
+    assert meta["num_records"] == 0
+    assert meta["name"] == "empty_ds"
+    assert meta["version"] == "v0"
+
+    spec_path = Path(tmp_path) / "empty_ds" / "spec.json"
+    assert not spec_path.exists()
+
+    meta_path = Path(tmp_path) / "empty_ds" / "meta.json"
+    with meta_path.open("r", encoding="utf-8") as f:
+        stored_meta = json.load(f)
+    assert stored_meta["num_records"] == 0


### PR DESCRIPTION
## Summary
- guard ArrayRecordBuilder spec persistence when no samples are produced
- ensure empty builds clear stale specs and keep metadata record counts accurate
- add regression test covering empty stream preparation

## Testing
- python - <<'PY'
from pathlib import Path
import sys
import crossformer

crossformer.ROOT = Path.cwd()

import pytest

sys.exit(pytest.main(["tests/grain/arec/test_arec_builder.py"]))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d48f80a6508329ab5beafd94128cfd