### PR TITLE
Enforce OXE dataset registration metadata

### DIFF
--- a/crossformer/cn/dataset/action.py
+++ b/crossformer/cn/dataset/action.py
@@ -7,7 +7,13 @@ from typing import Callable, ClassVar, Sequence
 from crossformer.cn.base import CN, default
 from crossformer.cn.dataset.mix import DataSource
 from crossformer.cn.dataset.types import HEAD2SPACE, ActionRep, ActionSpace
-from crossformer.data.oxe.oxe_dataset_configs import ProprioDim
+from crossformer.data.oxe.oxe_dataset_configs import (
+    OXE_DATASET_CONFIGS,
+    ProprioDim,
+)
+from crossformer.data.oxe.oxe_standardization_transforms import (
+    OXE_STANDARDIZATION_TRANSFORMS,
+)
 from crossformer.data.utils.data_utils import NormalizationType
 from crossformer.utils.spec import ModuleSpec
 
@@ -69,7 +75,14 @@ class DataSpec(CN):
     action_encoding: ActionSpace = ActionSpace.NONE
 
     def __post_init__(self):
+        parent_post_init = getattr(super(), "__post_init__", None)
+        if parent_post_init:
+            parent_post_init()
         self.REGISTRY[self.name] = self
+        assert self.name in OXE_DATASET_CONFIGS, f"{self.name} missing OXE config"
+        assert (
+            self.name in OXE_STANDARDIZATION_TRANSFORMS
+        ), f"{self.name} missing OXE standardization"
 
     @property
     def action_space(self):

--- a/crossformer/cn/dataset/mix.py
+++ b/crossformer/cn/dataset/mix.py
@@ -5,6 +5,11 @@ import tyro
 
 from crossformer.cn.base import CN
 from crossformer.cn.dataset.types import Head
+from crossformer.data.oxe.oxe_dataset_configs import OXE_DATASET_CONFIGS
+from crossformer.data.oxe.oxe_dataset_mixes import HEAD_TO_DATASET
+from crossformer.data.oxe.oxe_standardization_transforms import (
+    OXE_STANDARDIZATION_TRANSFORMS,
+)
 
 
 @dataclass
@@ -16,6 +21,16 @@ class DataSource(CN):
 
     def __post_init__(self):
         self.REGISTRY[self.name] = self
+        members = {
+            dataset
+            for datasets in HEAD_TO_DATASET.values()
+            for dataset in datasets
+        }
+        assert self.name in members, f"{self.name} missing from HEAD_TO_DATASET"
+        assert self.name in OXE_DATASET_CONFIGS, f"{self.name} missing OXE config"
+        assert (
+            self.name in OXE_STANDARDIZATION_TRANSFORMS
+        ), f"{self.name} missing OXE standardization"
 
     def flatten(self):
         return [(self.name, 1.0)]

--- a/crossformer/data/oxe/oxe_dataset_configs.py
+++ b/crossformer/data/oxe/oxe_dataset_configs.py
@@ -181,6 +181,7 @@ OXE_DATASET_CONFIGS = {
     "xgym_lift_single": xgym,
     "xgym_duck_single": xgym,
     "xgym_stack_single": xgym,
+    "xgym_sweep_single": xgym,
     "xgym_play_single": xgym,
     "xgym_single": xgym,
     # "rlds_oakink": mano,  # OAK INK Dataset

--- a/crossformer/data/oxe/oxe_dataset_mixes.py
+++ b/crossformer/data/oxe/oxe_dataset_mixes.py
@@ -14,6 +14,7 @@ HEAD_TO_DATASET = {
         "xgym_lift_single",
         "xgym_stack_single",
         "xgym_duck_single",
+        "xgym_sweep_single",
         #
         "berkeley_mvp_converted_externally_to_rlds",
         "nyu_rot_dataset_converted_externally_to_rlds",

--- a/crossformer/data/oxe/oxe_standardization_transforms.py
+++ b/crossformer/data/oxe/oxe_standardization_transforms.py
@@ -1,12 +1,14 @@
 import itertools
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from jax.scipy.spatial.transform import Rotation
 import numpy as np
 import tensorflow as tf
 
-from crossformer.cn.dataset.action import XGYM, DataSpec
 from crossformer.cn.dataset.types import ActionRep, ActionSpace
+
+if TYPE_CHECKING:
+    from crossformer.cn.dataset.action import DataSpec, XGYM
 
 METRIC_WAYPOINT_SPACING = {
     "cory_hall": 0.06,
@@ -141,6 +143,8 @@ def xgym_mano_dataset_transform(trajectory: dict[str, Any]) -> dict[str, Any]:
 def xgym_single_dataset_transform(trajectory: dict[str, Any]) -> dict[str, Any]:
     obs = trajectory.pop("observation")
     images = obs.pop("image")
+
+    from crossformer.cn.dataset.action import DataSpec, XGYM
 
     xcfg = DataSpec.REGISTRY["xgym_stack_single"]
     assert isinstance(xcfg, XGYM)


### PR DESCRIPTION
## Summary
- assert that CN data sources register only when backed by OXE dataset metadata and standardization transforms
- enforce matching OXE configs for DataSpec registrations and make xgym_sweep_single metadata complete
- decouple the OXE standardization module imports to avoid circular dependencies

## Testing
- pytest tests/test_action_heads_and_flow.py *(fails: ModuleNotFoundError: No module named 'jax')*

------
https://chatgpt.com/codex/tasks/task_e_68d4ab3f13e88329a6ed11a22a74011a