### PR TITLE
Refine visualize_data dataset wrappers

### DIFF
--- a/scripts/debug/visualize_data.py
+++ b/scripts/debug/visualize_data.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 import logging
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable, Sequence
 
 from array_record.python.array_record_data_source import ArrayRecordDataSource
 import matplotlib.pyplot as plt
@@ -28,11 +29,213 @@ class _DecodedArrayRecord:
     def __init__(self, shards: Iterable[Path]):
         self._ds = ArrayRecordDataSource([str(p) for p in sorted(shards)])
 
-    def __len__(self) -> int:
+    def __len__(self) -> int:  # pragma: no cover - simple delegation
         return len(self._ds)
 
-    def __getitem__(self, index: int):
+    def __getitem__(self, index: int):  # pragma: no cover - simple delegation
         return unpack_record(self._ds[index])
+
+
+class _EpisodeDataset(Sequence[dict]):
+    """Aggregates step-wise records into per-episode trajectories."""
+
+    def __init__(self, records: _DecodedArrayRecord):  # noqa: D401
+        self._records = records
+        self._episode_indices = self._group_indices()
+
+    def _group_indices(self) -> list[list[int]]:
+        by_episode: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        for idx in range(len(self._records)):
+            record = self._records[idx]
+            episode_id = int(record.get("episode_id", 0))
+            step_id = int(record.get("step_id", idx))
+            by_episode[episode_id].append((step_id, idx))
+        grouped = []
+        for _, pairs in sorted(by_episode.items()):
+            pairs.sort(key=lambda pair: pair[0])
+            grouped.append([idx for _, idx in pairs])
+        return grouped
+
+    def __len__(self) -> int:
+        return len(self._episode_indices)
+
+    def __getitem__(self, index: int) -> dict:
+        indices = self._episode_indices[index]
+        steps = [self._records[i] for i in indices]
+        return _assemble_episode(steps)
+
+
+class _DropKeyDataset(Sequence[dict]):
+    """Dataset wrapper that filters observation keys."""
+
+    def __init__(self, dataset: Sequence[dict], drop_keys: Sequence[str] = ()):  # noqa: D401
+        self._dataset = dataset
+        self._drop_keys = set(drop_keys)
+
+    def __len__(self) -> int:
+        return len(self._dataset)
+
+    def __getitem__(self, index: int) -> dict:
+        traj = self._dataset[index]
+        if not self._drop_keys:
+            return traj
+        return _drop_observation_keys(traj, self._drop_keys)
+
+
+def _assemble_episode(steps: Sequence[dict]) -> dict:
+    """Convert a list of step dictionaries into a trajectory dictionary."""
+
+    if not steps:
+        return {}
+
+    obs_buffers: dict[str, list[np.ndarray]] = {}
+    proprio_buffers: dict[str, list[np.ndarray]] = {}
+    action_buffers: dict[str, list[np.ndarray]] = {}
+
+    rewards = []
+    discounts = []
+    is_first = []
+    is_last = []
+    is_terminal = []
+    language = []
+    embeddings = []
+
+    for step in sorted(steps, key=lambda s: s.get("step_id", 0)):
+        rewards.append(float(step.get("reward", 0.0)))
+        discounts.append(float(step.get("discount", 1.0)))
+        is_first.append(bool(step.get("is_first", False)))
+        is_last.append(bool(step.get("is_last", False)))
+        is_terminal.append(bool(step.get("is_terminal", False)))
+
+        if "language_instruction" in step:
+            language.append(step["language_instruction"])
+        if "language_embedding" in step:
+            embeddings.append(np.asarray(step["language_embedding"], dtype=np.float32))
+
+        obs = step.get("observation", {})
+        for key, value in obs.items():
+            if key == "proprio" and isinstance(value, dict):
+                for p_key, p_val in value.items():
+                    proprio_buffers.setdefault(p_key, []).append(
+                        np.asarray(p_val, dtype=np.float32)
+                    )
+                continue
+            if isinstance(value, dict):
+                for sub_key, sub_val in value.items():
+                    flat_key = f"{key}_{sub_key}"
+                    obs_buffers.setdefault(flat_key, []).append(np.asarray(sub_val))
+                continue
+            obs_buffers.setdefault(key, []).append(np.asarray(value))
+
+        action = step.get("action", {})
+        if isinstance(action, dict):
+            for a_key, a_val in action.items():
+                action_buffers.setdefault(a_key, []).append(
+                    np.asarray(a_val, dtype=np.float32)
+                )
+
+    traj_len = len(steps)
+    obs_out: dict[str, np.ndarray | dict[str, np.ndarray]] = {
+        key: np.stack(frames) for key, frames in obs_buffers.items()
+    }
+    if proprio_buffers:
+        obs_out["proprio"] = {
+            key: np.stack(frames).astype(np.float32)
+            for key, frames in proprio_buffers.items()
+        }
+        for key, frames in proprio_buffers.items():
+            flat_key = f"proprio_{key}"
+            obs_out[flat_key] = np.stack(frames).astype(np.float32)
+
+    action_components = []
+    for part in ("joints", "gripper", "position"):
+        if part in action_buffers:
+            action_components.append(np.stack(action_buffers[part]))
+    if action_components:
+        action_out = np.concatenate(action_components, axis=-1).astype(np.float32)
+    else:
+        action_out = np.zeros((traj_len, 0), dtype=np.float32)
+
+    traj: dict[str, Any] = {
+        "observation": obs_out,
+        "action": action_out,
+        "reward": np.asarray(rewards, dtype=np.float32),
+        "discount": np.asarray(discounts, dtype=np.float32),
+        "is_first": np.asarray(is_first, dtype=bool),
+        "is_last": np.asarray(is_last, dtype=bool),
+        "is_terminal": np.asarray(is_terminal, dtype=bool),
+        "episode_id": steps[0].get("episode_id"),
+    }
+
+    if language:
+        traj["language_instruction"] = language[0]
+    if embeddings:
+        traj["language_embedding"] = embeddings[0]
+
+    return traj
+
+
+def _drop_observation_keys(traj: dict, drop_keys: set[str]) -> dict:
+    obs = traj.get("observation")
+    if not isinstance(obs, dict) or not drop_keys:
+        return traj
+
+    filtered: dict[str, Any] = {}
+    for key, value in obs.items():
+        if _should_drop(drop_keys, key):
+            continue
+        if isinstance(value, dict):
+            if key == "proprio":
+                nested = {
+                    sub_key: sub_val
+                    for sub_key, sub_val in value.items()
+                    if not _should_drop(drop_keys, f"{key}_{sub_key}", sub_key, f"{key}/{sub_key}")
+                }
+                if nested:
+                    filtered[key] = nested
+                continue
+            filtered[key] = value
+            continue
+        filtered[key] = value
+
+    new_traj = dict(traj)
+    new_traj["observation"] = filtered
+    return new_traj
+
+
+def _should_drop(drop_keys: set[str], *candidates: str) -> bool:
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        for alias in _expand_aliases(candidate):
+            if alias in drop_keys:
+                return True
+    return False
+
+
+def _expand_aliases(key: str) -> set[str]:
+    if not key:
+        return {""}
+
+    aliases = {key}
+    cleaned = key.lstrip("/")
+    aliases.add(cleaned)
+
+    if "_" in cleaned:
+        prefix, suffix = cleaned.split("_", 1)
+        aliases.add(suffix)
+        if prefix:
+            aliases.add(f"{prefix}/{suffix}")
+
+    if "/" in cleaned:
+        prefix, suffix = cleaned.split("/", 1)
+        if prefix:
+            aliases.add(f"{prefix}_{suffix}")
+        aliases.add(suffix)
+
+    aliases.add(cleaned.split("/")[-1])
+
+    return {alias for alias in aliases if alias}
 
 
 def _infer_observation_mappings(traj: dict) -> tuple[dict, dict, dict, dict] | None:
@@ -124,6 +327,7 @@ class Config(cn.Train):
     dataset_name: str | None = None
     log_every: int = 20
     fps: int = 8
+    drop_observation_keys: tuple[str, ...] = ()
 
 
 def main(cfg: Config) -> None:
@@ -132,7 +336,9 @@ def main(cfg: Config) -> None:
     shards = sorted(cfg.arec_path.glob("*.arrayrecord"))
     if not shards:
         raise FileNotFoundError(f"No ArrayRecord shards found in {cfg.arec_path}")
-    source = _DecodedArrayRecord(shards)
+    records = _DecodedArrayRecord(shards)
+    source = _EpisodeDataset(records)
+    source = _DropKeyDataset(source, drop_keys=cfg.drop_observation_keys)
 
     first_traj = source[0]
     mappings = _infer_observation_mappings(first_traj)


### PR DESCRIPTION
## Summary
- keep `_EpisodeDataset` focused on assembling trajectories and introduce `_DropKeyDataset` to filter observation keys
- add reusable helpers to drop observation entries by alias while preserving proprio aggregation
- update visualize script to chain the new dataset wrappers when building trajectory datasets

## Testing
- python -m compileall scripts/debug/visualize_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d4cc2cac648329b53416109ced0485