### PR TITLE
Add branch support and dataset reformatter

### DIFF
--- a/crossformer/data/grain/arec/arec.py
+++ b/crossformer/data/grain/arec/arec.py
@@ -113,6 +113,7 @@ class ArrayRecordBuilder:
             name="tinystories",
             root="~/.cache/arrds",
             version="v1",  # bump when schema changes
+            branch="main",  # logical branch under the dataset/version
             shard_size=200_000,  # records per shard
             writer_options="group_size:32",  # passed through to ArrayRecordWriter
         )
@@ -138,13 +139,15 @@ class ArrayRecordBuilder:
         self,
         name: str,
         version: str,
+        branch: str = "main",
         root: str = Path("~/.cache/arrayrecords"),
         shard_size: int = 100_000,
         writer_options: str | None = "group_size:1",
         build_meta: dict[str, Any] | None = None,  # things that affect schema
     ):
         self.name = name
-        self.root = Path(root).expanduser() / name / version
+        self.branch = branch
+        self.root = Path(root).expanduser() / name / version / branch
         Path(self.root).mkdir(parents=True, exist_ok=True)
         self.version = version
         self.shard_size = int(shard_size)
@@ -254,6 +257,7 @@ class ArrayRecordBuilder:
         meta = {
             "name": self.name,
             "version": self.version,
+            "branch": self.branch,
             "schema_fingerprint": _schema_fingerprint(self.version, self.build_meta),
             "writer_options": self.writer_options or "",
             "shard_size": self.shard_size,
@@ -280,6 +284,7 @@ class ArrayRecordBuilder:
             self._meta = {
                 "name": self.name,
                 "version": self.version,
+                "branch": self.branch,
                 "num_records": len(self._ds),
             }
 
@@ -298,6 +303,7 @@ class ArrayRecordBuilder:
                 self._meta = {
                     "name": self.name,
                     "version": self.version,
+                    "branch": self.branch,
                     "num_records": len(self._ds),
                 }
         return self._meta

--- a/crossformer/data/grain/arec/compile.py
+++ b/crossformer/data/grain/arec/compile.py
@@ -275,7 +275,7 @@ def main(cfg: Config) -> None:
 
     ds = arec.ArrayRecordBuilder(
         name=builder.name,
-        root=str(Path("~/.cache/arrayrecords") / builder.name / cfg.version),
+        root=str(Path("~/.cache/arrayrecords")),
         version=cfg.version,  # bump when schema/layout changes
         shard_size=1,  # records per shard
         writer_options="group_size:1",  # passed directly to ArrayRecordWriter

--- a/scripts/reformat_arec.py
+++ b/scripts/reformat_arec.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import chain
+from pathlib import Path
+from typing import Iterable, Iterator, Literal
+
+import numpy as np
+import tyro
+
+from crossformer.data.grain.arec.arec import ArrayRecordBuilder
+
+
+def _record_mode(sample: dict) -> Literal["episode", "step"]:
+    return "step" if "step_id" in sample else "episode"
+
+
+def _episode_length(sample: dict) -> int:
+    def _find(x) -> int | None:
+        if isinstance(x, np.ndarray) and x.ndim:
+            return x.shape[0]
+        if isinstance(x, dict):
+            for v in x.values():
+                l = _find(v)
+                if l is not None:
+                    return l
+        return None
+
+    length = _find(sample)
+    if length is None:
+        raise ValueError("Unable to infer episode length from sample.")
+    return length
+
+
+def _slice_sample(sample: dict, idx: int, length: int):
+    if isinstance(sample, dict):
+        return {k: _slice_sample(v, idx, length) for k, v in sample.items()}
+    if isinstance(sample, np.ndarray) and sample.ndim and sample.shape[0] == length:
+        return sample[idx]
+    return sample
+
+
+def _episode_to_steps(sample: dict) -> Iterator[dict]:
+    length = _episode_length(sample)
+    for idx in range(length):
+        step = _slice_sample(sample, idx, length)
+        step.setdefault("step_id", idx)
+        yield step
+
+
+def _stack_values(values: list):
+    first = values[0]
+    if isinstance(first, dict):
+        return {k: _stack_values([v[k] for v in values]) for k in first}
+    if isinstance(first, np.ndarray):
+        return np.stack(values)
+    if all(v == first for v in values):
+        return first
+    return np.asarray(values)
+
+
+def _steps_to_episode(steps: list[dict]) -> dict:
+    keys = steps[0].keys()
+    return {k: _stack_values([s[k] for s in steps]) for k in keys}
+
+
+def _episode_stream_to_steps(first: dict, rest: Iterable[dict]) -> Iterator[dict]:
+    for sample in chain([first], rest):
+        yield from _episode_to_steps(sample)
+
+
+def _steps_stream_to_episodes(first: dict, rest: Iterable[dict]) -> Iterator[dict]:
+    current = None
+    buffer: list[dict] = []
+    for sample in chain([first], rest):
+        episode_id = sample.get("episode_id")
+        if current is not None and episode_id != current:
+            yield _steps_to_episode(buffer)
+            buffer = []
+        current = episode_id
+        buffer.append(sample)
+    if buffer:
+        yield _steps_to_episode(buffer)
+
+
+@dataclass
+class ReformatConfig:
+    name: str
+    version: str
+    to: Literal["episode", "step"]
+    root: Path = Path("~/.cache/arrayrecords")
+    branch: str = "main"
+    shard_size: int = 100_000
+    writer_options: str | None = "group_size:1"
+
+
+def main(cfg: ReformatConfig):
+    reader = ArrayRecordBuilder(
+        name=cfg.name,
+        version=cfg.version,
+        branch=cfg.branch,
+        root=cfg.root,
+        shard_size=cfg.shard_size,
+        writer_options=cfg.writer_options,
+    )
+
+    source = iter(reader)
+    try:
+        first = next(source)
+    except StopIteration:
+        raise SystemExit("Source dataset is empty.")
+
+    mode = _record_mode(first)
+
+    if cfg.to == "step":
+        build_fn = lambda: _episode_stream_to_steps(first, source) if mode == "episode" else chain([first], source)
+    else:
+        build_fn = (
+            lambda: _steps_stream_to_episodes(first, source)
+            if mode == "step"
+            else chain([first], source)
+        )
+
+    writer = ArrayRecordBuilder(
+        name=cfg.name,
+        version=cfg.version,
+        branch=f"to_{cfg.to}",
+        root=cfg.root,
+        shard_size=cfg.shard_size,
+        writer_options=cfg.writer_options,
+    )
+    writer.prepare(build_fn)
+
+
+if __name__ == "__main__":
+    main(tyro.cli(ReformatConfig))

--- a/tests/grain/arec/test_arec_builder.py
+++ b/tests/grain/arec/test_arec_builder.py
@@ -21,10 +21,10 @@ def test_prepare_empty_stream(tmp_path):
     assert meta["name"] == "empty_ds"
     assert meta["version"] == "v0"
 
-    spec_path = Path(tmp_path) / "empty_ds" / "spec.json"
+    spec_path = Path(tmp_path) / "empty_ds" / "v0" / "main" / "spec.json"
     assert not spec_path.exists()
 
-    meta_path = Path(tmp_path) / "empty_ds" / "meta.json"
+    meta_path = Path(tmp_path) / "empty_ds" / "v0" / "main" / "meta.json"
     with meta_path.open("r", encoding="utf-8") as f:
         stored_meta = json.load(f)
     assert stored_meta["num_records"] == 0


### PR DESCRIPTION
## Summary
- add a branch parameter to ArrayRecordBuilder paths and metadata
- update builder consumers to assume the new branch-aware root layout
- add a conversion script to rewrite ArrayRecord datasets between episode and step formats

## Testing
- python -m pytest tests/grain/arec/test_arec_builder.py tests/grain/arec/test_arec_iteration.py *(fails: ModuleNotFoundError: No module named 'jax')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943643f6b48832982bb4ccbf3ce1fe7)