### PR TITLE
Feat/drop: add dropout methods

### DIFF
--- a/crossformer/cn/model_factory.py
+++ b/crossformer/cn/model_factory.py
@@ -93,6 +93,7 @@ class ModelFactory(CN):
     vision: Vision = Vision().field()
     xflow: XFlow = XFlow().field()
     debug: bool = False
+    proprio_token_drop_prob: float = 0.0
 
     @property
     def heads(self) -> list[str]:
@@ -158,7 +159,9 @@ class ModelFactory(CN):
         return flat
 
     def make_obs_proprio(self, key: str) -> LowdimTokenizerCfg:
-        return LowdimTokenizerCfg(name=key, obs_keys=(f"proprio_{key}",), dropout_rate=0.2)
+        return LowdimTokenizerCfg(
+            name=key, obs_keys=(f"proprio_{key}",), dropout_rate=0.2, p_token_drop=self.proprio_token_drop_prob
+        )
 
     def make_obs_im(self, key: str, *, encoder: ModuleSpec) -> ImageTokenizerCfg:
         # DINOv3 takes 3-channel inputs only — disable channel-stacked goal images + FiLM.

--- a/crossformer/data/grain/loader.py
+++ b/crossformer/data/grain/loader.py
@@ -268,6 +268,7 @@ class GrainDataFactory:
     patch_prob: float = 0.0
     patch_min_frac: float = 0.05
     patch_max_frac: float = 0.5
+    view_drop_prob: float = 0.0
 
     def source2ds(self, dconfig, cfg: cn.Train, dataset: Arec, max_a: int = 0) -> GrainDataLoader:
         ds, stats = make_single_dataset(
@@ -401,6 +402,16 @@ class GrainDataFactory:
                     prob=self.patch_prob,
                     min_frac=self.patch_min_frac,
                     max_frac=self.patch_max_frac,
+                ),
+                seed=cfg.seed,
+            )
+
+        if train and self.view_drop_prob > 0:
+            ds = ds.random_map(
+                lambda x, rng: transforms.image_view_drop(
+                    x,
+                    rng,
+                    prob=self.view_drop_prob,
                 ),
                 seed=cfg.seed,
             )

--- a/crossformer/data/grain/loader.py
+++ b/crossformer/data/grain/loader.py
@@ -269,6 +269,7 @@ class GrainDataFactory:
     patch_min_frac: float = 0.05
     patch_max_frac: float = 0.5
     view_drop_prob: float = 0.0
+    image_shuffle_prob: float = 0.0
 
     def source2ds(self, dconfig, cfg: cn.Train, dataset: Arec, max_a: int = 0) -> GrainDataLoader:
         ds, stats = make_single_dataset(
@@ -412,6 +413,16 @@ class GrainDataFactory:
                     x,
                     rng,
                     prob=self.view_drop_prob,
+                ),
+                seed=cfg.seed,
+            )
+
+        if train and self.image_shuffle_prob > 0:
+            ds = ds.random_map(
+                lambda x, rng: transforms.image_key_shuffle(
+                    x,
+                    rng,
+                    prob=self.image_shuffle_prob,
                 ),
                 seed=cfg.seed,
             )

--- a/crossformer/data/grain/loader.py
+++ b/crossformer/data/grain/loader.py
@@ -19,7 +19,7 @@ from rich import print
 
 from crossformer import cn
 from crossformer.cn.dataset.mix import Arec, MultiDataSource
-from crossformer.data.grain import builders
+from crossformer.data.grain import builders, transforms
 from crossformer.data.grain.datasets import (
     MultiArrayRecordSource,
     unpack_record,
@@ -265,6 +265,9 @@ class GrainDataFactory:
     # final image size; controls both mix_precompatibility cv2.resize and augmax.Resize.
     # None disables both stages (image stays at native size, no center_crop).
     resize: int | tuple[int, int] | None = (64, 64)
+    patch_prob: float = 0.0
+    patch_min_frac: float = 0.05
+    patch_max_frac: float = 0.5
 
     def source2ds(self, dconfig, cfg: cn.Train, dataset: Arec, max_a: int = 0) -> GrainDataLoader:
         ds, stats = make_single_dataset(
@@ -389,6 +392,18 @@ class GrainDataFactory:
         # blocks mp prefetch so that final jax ops can be main proc
         #
         ds = ThreadPrefetchIterDataset(ds, prefetch_buffer_size=2)
+
+        if train and self.patch_prob > 0:
+            ds = ds.random_map(
+                lambda x, rng: transforms.patch_occlude(
+                    x,
+                    rng,
+                    prob=self.patch_prob,
+                    min_frac=self.patch_min_frac,
+                    max_frac=self.patch_max_frac,
+                ),
+                seed=cfg.seed,
+            )
 
         ds = ds.map(np2jax)  # dont use jax+grain yet... buggy
         if shard_fn is not None:

--- a/crossformer/data/grain/loader.py
+++ b/crossformer/data/grain/loader.py
@@ -270,6 +270,7 @@ class GrainDataFactory:
     patch_max_frac: float = 0.5
     view_drop_prob: float = 0.0
     image_shuffle_prob: float = 0.0
+    proprio_drop_prob: float = 0.0
 
     def source2ds(self, dconfig, cfg: cn.Train, dataset: Arec, max_a: int = 0) -> GrainDataLoader:
         ds, stats = make_single_dataset(
@@ -423,6 +424,16 @@ class GrainDataFactory:
                     x,
                     rng,
                     prob=self.image_shuffle_prob,
+                ),
+                seed=cfg.seed,
+            )
+
+        if train and self.proprio_drop_prob > 0:
+            ds = ds.random_map(
+                lambda x, rng: transforms.proprio_sample_drop(
+                    x,
+                    rng,
+                    prob=self.proprio_drop_prob,
                 ),
                 seed=cfg.seed,
             )

--- a/crossformer/data/grain/pipelines.py
+++ b/crossformer/data/grain/pipelines.py
@@ -198,7 +198,7 @@ def do_frame_transforms(config, tfconfig, ds, *, imaug: bool = True, rotate: boo
 
     ds = (
         # @todo is it better to use mp or to jit with constant size?
-        ds.random_map(lambda x, rng: frame_aug_with_reshape(rng=rng_for_batch(rng, x), batch=x))
+        ds.random_map(lambda x, rng: frame_aug_with_reshape(rng=rng_for_batch(rng, x), batch=x), seed=42)
     )
     return ds
 

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -283,6 +283,7 @@ def image_view_drop(step: dict, rng, prob: float) -> dict:
     """
     print("keys at this stage")
     print(list(step["observation"].keys()), flush=True)
+    print(list(step["observation"]["pad_mask_dict"].keys()), flush=True)
     raise RuntimeError("check keys for image_view_drop")
 
     images = step["observation"]["image"]

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -314,6 +314,42 @@ def image_view_drop(step: dict, rng, prob: float) -> dict:
     }
 
 
+def image_key_shuffle(step: dict, rng, prob: float) -> dict:
+    """
+    Randomly shuffle camera views across camera slots for some samples.
+
+    For each sample, with probability 'prob', permutes which camera appears
+    in each image_* slot. pad_mask_dict travels with their view.
+    """
+    images = step["observation"]["image"]
+    pmd = step["observation"]["pad_mask_dict"]["image"]
+    views = list(images.keys())
+    b, K = images[views[0]].shape[0], len(views)
+
+    shuffled = rng.random(b) < prob
+    random_perm = np.argsort(rng.random((b, K)), axis=1)  # indirect sorting
+    perm = np.where(shuffled[:, None], random_perm, np.arange(K))
+
+    imgs = np.stack([images[v] for v in views], axis=1)
+    masks = np.stack([np.asarray(pmd[v]) for v in views], axis=1)
+
+    bi = np.arange(b)[:, None]  # batch indices
+    new_imgs = imgs[bi, perm]
+    new_masks = masks[bi, perm]
+
+    new_images = {v: new_imgs[:, i] for i, v in enumerate(views)}
+    new_pmd = {v: new_masks[:, i] for i, v in enumerate(views)}
+
+    return {
+        **step,
+        "observation": {
+            **step["observation"],
+            "image": new_images,
+            "pad_mask_dict": {**step["observation"]["pad_mask_dict"], "image": new_pmd},
+        },
+    }
+
+
 def _normalize_resize_size(size: int | tuple[int, int]) -> tuple[int, int]:
     if isinstance(size, int):
         if size <= 0:

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -237,6 +237,38 @@ def zero_out_future_proprio(traj: Trajectory) -> Trajectory:
     return traj
 
 
+def patch_occlude(step: dict, rng, prob: float, min_frac: float = 0.05, max_frac: float = 0.5) -> dict:
+    """Randomly zero out a rectangular region in each image view.
+
+    For each (sample, timestep, view), with probability `prob` a rectangle of
+    random area (uniform in [min_frac, max_frac] of image area) and aspect
+    ratio (uniform in [0.5, 2.0]) is zeroed. Views are occluded independently.
+
+    Does not modify pad_mask_dict: an occluded image is still "present", just
+    corrupted. Use image_view_drop for whole-view removal.
+    """
+    images = step["observation"]["image"]
+
+    def patch_one(a):
+        b, t, h, w = a.shape[:4]  # potentially assert dim = 5
+        hit = rng.random((b, t)) < prob
+        frac = rng.uniform(min_frac, max_frac, size=(b, t))
+        aspect = rng.uniform(0.5, 2.0, size=(b, t))
+        ph = np.clip(np.sqrt(frac * h * w * aspect), 1, h).astype(int)  # patch height
+        pw = np.clip(np.sqrt(frac * h * w / aspect), 1, w).astype(int)  # patch width
+        y0 = rng.integers(0, np.maximum(h - ph, 1))  # top edge of patch
+        x0 = rng.integers(0, np.maximum(w - pw, 1))
+        ys = np.arange(h)  # row indexes
+        xs = np.arange(w)  # col indexes
+        y_in = (ys >= y0[..., None]) & (ys < (y0 + ph)[..., None])
+        x_in = (xs >= x0[..., None]) & (xs < (x0 + pw)[..., None])
+        patch = hit[..., None, None] & y_in[..., None] & x_in[..., None, :]
+        return np.where(patch[..., None], 0, a)
+
+    new_images = {v: patch_one(images[v]) for v in images}
+    return {**step, "observation": {**step["observation"], "image": new_images}}
+
+
 def _normalize_resize_size(size: int | tuple[int, int]) -> tuple[int, int]:
     if isinstance(size, int):
         if size <= 0:

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -250,6 +250,9 @@ def patch_occlude(step: dict, rng, prob: float, min_frac: float = 0.05, max_frac
     images = step["observation"]["image"]
 
     def patch_one(a):
+        squeezed = a.ndim == 4
+        if squeezed:
+            a = a[:, None]  # add time dim
         b, t, h, w = a.shape[:4]  # potentially assert dim = 5
         hit = rng.random((b, t)) < prob
         frac = rng.uniform(min_frac, max_frac, size=(b, t))
@@ -263,7 +266,8 @@ def patch_occlude(step: dict, rng, prob: float, min_frac: float = 0.05, max_frac
         y_in = (ys >= y0[..., None]) & (ys < (y0 + ph)[..., None])
         x_in = (xs >= x0[..., None]) & (xs < (x0 + pw)[..., None])
         patch = hit[..., None, None] & y_in[..., None] & x_in[..., None, :]
-        return np.where(patch[..., None], 0, a)
+        out = np.where(patch[..., None], 0, a)
+        return out[:, 0] if squeezed else out
 
     new_images = {v: patch_one(images[v]) for v in images}
     return {**step, "observation": {**step["observation"], "image": new_images}}

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -278,12 +278,12 @@ def image_view_drop(step: dict, rng, prob: float) -> dict:
     Randomly drop entire image views for some batch samples.
 
     For each sample with probability `prob`, one randomly chosen
-    camera viwe is zeroed across all timesteps. pad_mask_dict is
+    camera view  is zeroed across all timesteps. pad_mask_dict is
     updated so downstreams treat the dropped view as padding.
     """
     print("keys at this stage")
     print(list(step["observation"].keys()), flush=True)
-    print(list(step["observation"]["pad_mask_dict"]["image"].keys()), flush=True)
+    print(list(step["observation"]["pad_mask_dict"]["image"]["low"].shape, flush=True))
     raise RuntimeError("check keys for image_view_drop")
 
     images = step["observation"]["image"]

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -350,6 +350,45 @@ def image_key_shuffle(step: dict, rng, prob: float) -> dict:
     }
 
 
+def proprio_sample_drop(step: dict, rng, prob: float) -> dict:
+    """
+    Randomly zero all proprio for some samples (mimics total proprio sensor loss).
+
+    One Bernoulli hit per sample with probability 'prob'. On hit, every
+    proprio subkey is zeroed and every proprio pmd entry is flipped to False
+    across all timesteps. Subkeys move together - per-subkey independence
+    is handled later by proprio_token_drop.
+    """
+    proprio = step["observation"]["proprio"]
+    pmd = step["observation"]["pad_mask_dict"]
+    pmd_p = pmd["proprio"]
+    keys = list(proprio.keys())
+    b = proprio[keys[0]].shape[0]
+
+    drop = rng.random(b) < prob
+
+    def zero(x):
+        return np.where(drop.reshape((b,) + (1,) * (x.ndim - 1)), 0, x)
+
+    new_proprio = {k: zero(proprio[k]) for k in keys}
+
+    def new_mask(k):
+        existing = np.asarray(pmd_p[k], dtype=bool)
+        d = drop.reshape((b,) + (1,) * (existing.ndim - 1))
+        return existing & ~d
+
+    new_pmd_p = {k: new_mask(k) for k in keys}
+
+    return {
+        **step,
+        "observation": {
+            **step["observation"],
+            "proprio": new_proprio,
+            "pad_mask_dict": {**pmd, "proprio": new_pmd_p},
+        },
+    }
+
+
 def _normalize_resize_size(size: int | tuple[int, int]) -> tuple[int, int]:
     if isinstance(size, int):
         if size <= 0:

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -273,6 +273,44 @@ def patch_occlude(step: dict, rng, prob: float, min_frac: float = 0.05, max_frac
     return {**step, "observation": {**step["observation"], "image": new_images}}
 
 
+def image_view_drop(step: dict, rng, prob: float) -> dict:
+    """
+    Randomly drop entire image views for some batch samples.
+
+    For each sample with probability `prob`, one randomly chosen
+    camera viwe is zeroed across all timesteps. pad_mask_dict is
+    updated so downstreams treat the dropped view as padding.
+    """
+    print("keys at this stage")
+    print(list(step["observation"].keys()), flush=True)
+    raise RuntimeError("check keys for image_view_drop")
+
+    images = step["observation"]["image"]
+    views = list(images.keys())
+    batch_size = images[views[0]].shape[0]
+
+    drop = {v: rng.random(batch_size) < prob for v in views}
+
+    # potentially check if all views dropped unless desired
+    def zero_view(img, d):
+        return np.where(d.respape((b,) + (1,) * (img.ndim - 1)), 0, img)
+
+    new_images = {v: zero_view(images[v], drop[v]) for v in views}
+
+    pmd = step["observation"].get("pad_mask_dict", {})
+
+    def new_mask(v):
+        existing = np.asarray(pmd.get(v, np.ones(images[v].shape[:2], dtype=bool)), dtype=bool)
+        return existing & ~drop[v][:, None]
+
+    new_pmd = {**pmd, **{v: new_mask(v) for v in views}}
+
+    return {
+        **step,
+        "observation": {**step["observation"], "image": new_images, "pad_mask_dict": new_pmd},
+    }
+
+
 def _normalize_resize_size(size: int | tuple[int, int]) -> tuple[int, int]:
     if isinstance(size, int):
         if size <= 0:

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -283,7 +283,7 @@ def image_view_drop(step: dict, rng, prob: float) -> dict:
     """
     print("keys at this stage")
     print(list(step["observation"].keys()), flush=True)
-    print(list(step["observation"]["pad_mask_dict"].keys()), flush=True)
+    print(list(step["observation"]["pad_mask_dict"]["image"].keys()), flush=True)
     raise RuntimeError("check keys for image_view_drop")
 
     images = step["observation"]["image"]

--- a/crossformer/data/grain/transforms.py
+++ b/crossformer/data/grain/transforms.py
@@ -277,38 +277,40 @@ def image_view_drop(step: dict, rng, prob: float) -> dict:
     """
     Randomly drop entire image views for some batch samples.
 
-    For each sample with probability `prob`, one randomly chosen
-    camera view  is zeroed across all timesteps. pad_mask_dict is
-    updated so downstreams treat the dropped view as padding.
+    For each (sample, view) with probability 'prob' across
+    all timesteps, the view is zeroed across all timesteps
+    and pmd entry flipped to False.
+    Views drop independently.
     """
-    print("keys at this stage")
-    print(list(step["observation"].keys()), flush=True)
-    print(list(step["observation"]["pad_mask_dict"]["image"]["low"].shape, flush=True))
-    raise RuntimeError("check keys for image_view_drop")
-
+    # raise RuntimeError("check keys for image_view_drop")
     images = step["observation"]["image"]
+    pmd = step["observation"]["pad_mask_dict"]
+    pmd_img = pmd["image"]
     views = list(images.keys())
-    batch_size = images[views[0]].shape[0]
+    b = images[views[0]].shape[0]
+    # given view independence, small chance for all views to drop
+    # can add rescue if needed
+    drop = {v: rng.random(b) < prob for v in views}
 
-    drop = {v: rng.random(batch_size) < prob for v in views}
-
-    # potentially check if all views dropped unless desired
     def zero_view(img, d):
-        return np.where(d.respape((b,) + (1,) * (img.ndim - 1)), 0, img)
+        return np.where(d.reshape((b,) + (1,) * (img.ndim - 1)), 0, img)
 
     new_images = {v: zero_view(images[v], drop[v]) for v in views}
 
-    pmd = step["observation"].get("pad_mask_dict", {})
-
     def new_mask(v):
-        existing = np.asarray(pmd.get(v, np.ones(images[v].shape[:2], dtype=bool)), dtype=bool)
-        return existing & ~drop[v][:, None]
+        existing = np.asarray(pmd_img[v], dtype=bool)
+        d = drop[v].reshape((b,) + (1,) * (existing.ndim - 1))
+        return existing & ~d
 
-    new_pmd = {**pmd, **{v: new_mask(v) for v in views}}
+    new_pmd_img = {v: new_mask(v) for v in views}
 
     return {
         **step,
-        "observation": {**step["observation"], "image": new_images, "pad_mask_dict": new_pmd},
+        "observation": {
+            **step["observation"],
+            "image": new_images,
+            "pad_mask_dict": {**pmd, "image": new_pmd_img},
+        },
     }
 
 

--- a/crossformer/model/components/tokenizers.py
+++ b/crossformer/model/components/tokenizers.py
@@ -287,6 +287,7 @@ class LowdimObsTokenizer(BinTokenizer):
     discretize: bool = False
     use_obs_mask: bool = True
     dropout_rate: float = 0.0
+    p_token_drop: float = 0.0
 
     def setup(self):
         super().setup()
@@ -316,5 +317,10 @@ class LowdimObsTokenizer(BinTokenizer):
             tokens = jax.nn.one_hot(tokenized_inputs, self.n_bins)
         else:
             tokens = tokenizer_inputs[..., None]
-        mask = jnp.ones(tokens.shape[:-1])
+        mask = jnp.ones(tokens.shape[:-1], dtype=bool)
+        if train and self.p_token_drop > 0:
+            rng = self.make_rng("dropout")
+            keep = jax.random.bernoulli(rng, 1 - self.p_token_drop, mask.shape)
+            mask = mask & keep
+        jax.debug.print("[{name}] mask.mean={m} shape={s}", name=self.name, m=mask.mean(), s=mask.shape)
         return TokenGroup(tokens, mask)

--- a/crossformer/model/components/tokenizers.py
+++ b/crossformer/model/components/tokenizers.py
@@ -322,5 +322,4 @@ class LowdimObsTokenizer(BinTokenizer):
             rng = self.make_rng("dropout")
             keep = jax.random.bernoulli(rng, 1 - self.p_token_drop, mask.shape)
             mask = mask & keep
-        jax.debug.print("[{name}] mask.mean={m} shape={s}", name=self.name, m=mask.mean(), s=mask.shape)
         return TokenGroup(tokens, mask)

--- a/crossformer/model/config.py
+++ b/crossformer/model/config.py
@@ -47,6 +47,7 @@ class LowdimTokenizerCfg:
     low: float = 0.0
     high: float = 1.0
     dropout_rate: float = 0.0
+    p_token_drop: float = 0.0
 
     def create(self) -> ModuleSpec:
         return ModuleSpec.create(
@@ -58,6 +59,7 @@ class LowdimTokenizerCfg:
             low=self.low,
             high=self.high,
             dropout_rate=self.dropout_rate,
+            p_token_drop=self.p_token_drop,
         )
 
 

--- a/scripts/train/xflow.py
+++ b/scripts/train/xflow.py
@@ -208,8 +208,8 @@ def main(cfg: Config):
         rotate=cfg.rotate,
         resize=effective_resize,
         patch_prob=cfg.patch_prob,
-        patch_min_frac=cfg.patch_min_prob,
-        patch_max_prob=cfg.patch_max_prob,
+        patch_min_frac=cfg.patch_min_frac,
+        patch_max_frac=cfg.patch_max_frac,
     ).make(train_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=True)
     dsit = iter(dataset.dataset)
     example_batch = next(dsit)

--- a/scripts/train/xflow.py
+++ b/scripts/train/xflow.py
@@ -226,7 +226,7 @@ def main(cfg: Config):
         patch_prob=cfg.patch_prob,
         patch_min_frac=cfg.patch_min_frac,
         patch_max_frac=cfg.patch_max_frac,
-        view_drop_brob=cfg.view_drop_prob,
+        view_drop_prob=cfg.view_drop_prob,
     ).make(eval_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=False)
     print(spec(example_batch))
     inferred_image_keys, inferred_proprio_keys = infer_model_keys(example_batch["observation"])

--- a/scripts/train/xflow.py
+++ b/scripts/train/xflow.py
@@ -106,6 +106,7 @@ class Config:
     patch_max_frac: float = 0.5
     view_drop_prob: float = 0.0
     image_shuffle_prob: float = 0.0
+    proprio_drop_prob: float = 0.0
     viz: VizConfig = default(VizConfig())
     val_mse: ValMSEConfig = default(ValMSEConfig())
     rast: RastConfig = default(RastConfig())
@@ -214,6 +215,7 @@ def main(cfg: Config):
         patch_max_frac=cfg.patch_max_frac,
         view_drop_prob=cfg.view_drop_prob,
         image_shuffle_prob=cfg.image_shuffle_prob,
+        proprio_drop_prob=cfg.proprio_drop_prob,
     ).make(train_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=True)
     dsit = iter(dataset.dataset)
     example_batch = next(dsit)
@@ -230,6 +232,7 @@ def main(cfg: Config):
         patch_max_frac=cfg.patch_max_frac,
         view_drop_prob=cfg.view_drop_prob,
         image_shuffle_prob=cfg.image_shuffle_prob,
+        proprio_drop_prob=cfg.proprio_drop_prob,
     ).make(eval_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=False)
     print(spec(example_batch))
 

--- a/scripts/train/xflow.py
+++ b/scripts/train/xflow.py
@@ -101,6 +101,9 @@ class Config:
     hist_every: int = 0  # histogram log interval
     synth_viz_every: int = 0  # synth kp2d viz interval (0 = disabled)
     quit_after_model: bool = False  # stop after model creation for debugging
+    patch_prob: float = 0.0  # Probability of occluding each (sample, time, view)
+    patch_min_frac: float = 0.05
+    patch_max_frac: float = 0.5
     viz: VizConfig = default(VizConfig())
     val_mse: ValMSEConfig = default(ValMSEConfig())
     rast: RastConfig = default(RastConfig())
@@ -200,9 +203,14 @@ def main(cfg: Config):
         ),
         recompute=cfg.recompute,
     )
-    dataset = GrainDataFactory(mp=cfg.mp, rotate=cfg.rotate, resize=effective_resize).make(
-        train_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=True
-    )
+    dataset = GrainDataFactory(
+        mp=cfg.mp,
+        rotate=cfg.rotate,
+        resize=effective_resize,
+        patch_prob=cfg.patch_prob,
+        patch_min_frac=cfg.patch_min_prob,
+        patch_max_prob=cfg.patch_max_prob,
+    ).make(train_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=True)
     dsit = iter(dataset.dataset)
     example_batch = next(dsit)
     eval_dataset = GrainDataFactory(
@@ -213,6 +221,9 @@ def main(cfg: Config):
         imaug=False,
         rotate=cfg.rotate,
         resize=effective_resize,
+        patch_prob=cfg.patch_prob,
+        patch_min_frac=cfg.patch_min_frac,
+        patch_max_frac=cfg.patch_max_frac,
     ).make(eval_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=False)
     print(spec(example_batch))
     inferred_image_keys, inferred_proprio_keys = infer_model_keys(example_batch["observation"])

--- a/scripts/train/xflow.py
+++ b/scripts/train/xflow.py
@@ -105,6 +105,7 @@ class Config:
     patch_min_frac: float = 0.05
     patch_max_frac: float = 0.5
     view_drop_prob: float = 0.0
+    image_shuffle_prob: float = 0.0
     viz: VizConfig = default(VizConfig())
     val_mse: ValMSEConfig = default(ValMSEConfig())
     rast: RastConfig = default(RastConfig())
@@ -212,6 +213,7 @@ def main(cfg: Config):
         patch_min_frac=cfg.patch_min_frac,
         patch_max_frac=cfg.patch_max_frac,
         view_drop_prob=cfg.view_drop_prob,
+        image_shuffle_prob=cfg.image_shuffle_prob,
     ).make(train_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=True)
     dsit = iter(dataset.dataset)
     example_batch = next(dsit)
@@ -227,8 +229,10 @@ def main(cfg: Config):
         patch_min_frac=cfg.patch_min_frac,
         patch_max_frac=cfg.patch_max_frac,
         view_drop_prob=cfg.view_drop_prob,
+        image_shuffle_prob=cfg.image_shuffle_prob,
     ).make(eval_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=False)
     print(spec(example_batch))
+
     inferred_image_keys, inferred_proprio_keys = infer_model_keys(example_batch["observation"])
     obs_keys: tuple[str, ...] = ()
     print(f"  image_keys: {inferred_image_keys}")

--- a/scripts/train/xflow.py
+++ b/scripts/train/xflow.py
@@ -104,6 +104,7 @@ class Config:
     patch_prob: float = 0.0  # Probability of occluding each (sample, time, view)
     patch_min_frac: float = 0.05
     patch_max_frac: float = 0.5
+    view_drop_prob: float = 0.0
     viz: VizConfig = default(VizConfig())
     val_mse: ValMSEConfig = default(ValMSEConfig())
     rast: RastConfig = default(RastConfig())
@@ -210,6 +211,7 @@ def main(cfg: Config):
         patch_prob=cfg.patch_prob,
         patch_min_frac=cfg.patch_min_frac,
         patch_max_frac=cfg.patch_max_frac,
+        view_drop_prob=cfg.view_drop_prob,
     ).make(train_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=True)
     dsit = iter(dataset.dataset)
     example_batch = next(dsit)
@@ -224,6 +226,7 @@ def main(cfg: Config):
         patch_prob=cfg.patch_prob,
         patch_min_frac=cfg.patch_min_frac,
         patch_max_frac=cfg.patch_max_frac,
+        view_drop_brob=cfg.view_drop_prob,
     ).make(eval_cfg, shard_fn=partial(shard_batch, mesh=mesh), train=False)
     print(spec(example_batch))
     inferred_image_keys, inferred_proprio_keys = infer_model_keys(example_batch["observation"])


### PR DESCRIPTION
# Image augmentation primitives in the Grain pipeline

## Summary

Adds three per-sample image augmentations to the Grain data pipeline, each gated by an independent probability exposed on the tyro Config:

* **`patch_occlude`** - zero out a random rectangular patch in each image view
* **`image_view_drop`** - zero out entire views per `(sample, view)` and flip the corresponding `pad_mask_dict` entry to `False`
* **`image_key_shuffle`** - permute which view occupies which image-key slot, per sample, carrying `pad_mask_dict` along with the view

All three live in `crossformer/data/grain/transforms.py`, are wired into `GrainDataFactory` in `crossformer/data/grain/loader.py`, and surfaced via `Config` in `scripts/train/xflow.py`.

## Pipeline placement

The transforms sit in the main-process CPU stage, between `ThreadPrefetchIterDataset` and `np2jax` (see `loader.py:395-430`). This is intentional:

* **Before `np2jax`**: Tensors are still numpy, so we can mutate nested dicts cheaply and avoid round-tripping through JAX.
* **After `ThreadPrefetchIterDataset`**: The worker pool has already delivered batched samples, so the per-sample randomness runs once per batch rather than per trajectory.
* **Cost**: Each op is gated with `if train and self.<prob> > 0` so eval and default configs are no-ops (zero runtime cost).

Eval uses the same factory but with `prob=0` unless the user explicitly enables; the pass-through in the eval factory call mirrors train so that debug sweeps with nonzero prob also exercise the eval path if desired.

## Data-layout notes

At this stage the observation dict is still nested:

* `step["observation"]["image"][view]` -  shape `(B, T, H, W, C)` or `(B, H, W, C)` depending on upstream chunking.
* `step["observation"]["pad_mask_dict"]["image"][view]` - bool mask with matching leading dims.

The later `compatibility` transform flattens nested image keys to `image_<view>` post-GPU; we operate before that flattening so `images[view]` and `pmd[view]` are both directly indexable.

## `patch_occlude`

Per `(sample, timestep, view)` with probability `prob`, zero out a rectangular region with area fraction in `[min_frac, max_frac]` of `H*W` and aspect ratio in `[0.5, 2.0]`.

**Shape handling**: The array may arrive as 4D `(B, H, W, C)` or 5D `(B, T, H, W, C)`. `patch_one` inserts a time axis if missing, runs the masked write, and squeezes back. This is why the code looks like `squeezed = a.ndim == 4; if squeezed: a = a[:, None]; ...; return out[:, 0] if squeezed else out` -  defensive in case upstream chunking moves.

**Mask construction**: `y_in & x_in` are broadcast together to form a `(B, T, H, W)` boolean patch mask, which is then broadcast against the channel axis via `patch[..., None]`. All-numpy, no Python loops over samples.

## `image_view_drop`

Per `(sample, view)` with probability `prob`, zero the view across all timesteps and set `pad_mask_dict["image"][view]` to `False` for those samples.

**Views drop independently**: There is no "at least one survives" rescue. With K views at prob p, the probability that a sample loses all views is `p**K`, which is negligible for typical (p=0.1–0.3, K=3). If this ever matters, rescue logic belongs in this function, not downstream.

**Mask semantics**: The existing `pmd_img[v]` may already be `False` (upstream padding); the new mask is `existing & ~drop`, never flipping a previously-False entry to True.

## `image_key_shuffle`

Per sample with probability `prob`, permute which view occupies which image-key slot. Pad masks travel with the view.

**Why it's vectorized the way it is**:
* `rng.random(b) < prob` - per-sample Bernoulli hit.
* `np.argsort(rng.random((b, K)), axis=1)` - vectorized permutation trick. Sorting uniform noise gives a uniformly random permutation per row, with no loop over samples.
* `np.where(shuffled[:, None], random_perm, np.arange(K))` - unhit samples use the identity `[0..K-1]` permutation, so the gather below is a no-op for them.
* `imgs = np.stack([images[v] for v in views], axis=1)` → `(B, K, T, H, W, C)`. Stacking on axis 1 means the K axis is adjacent to B, which is what the advanced-indexing gather expects.
* **The gather**: `imgs[bi, perm]` where `bi = np.arange(b)[:, None]` is `(B, 1)` and `perm` is `(B, K)`. Numpy broadcasts `bi` across K so the paired index at `(row, col)` is `(row, perm[row, col])` - i.e. for each sample, pull view `perm[b, k]` into slot `k`. Without the `[:, None]` on `bi`, numpy would pair `bi[i]` with `perm[i, :]` along the same axis and the gather would not express per-sample permutations.

**Dict rebuild**: New dicts are keyed by the original `views` list in original order - the permutation changes what data lives at each key, not the key names themselves. This keeps downstream tokenizer wiring oblivious to the shuffle.

## `proprio_sample_drop`
Per sample with probability `prob`, zero **all** proprio subkeys and flip **all** `pmd` entries to False. One Bernoulli hit per sample, applied uniformly across every subkey.

**Semantics - total sensor loss**: this models the whole proprio sensor stack going away for a training sample. Per-subkey independence (e.g. joint present but pose missing) is not handled here, that is the job of an in-model `proprio_token_drop` operating at token granularity. Keeping coarse sample-level drop in Grain and the fine per-key drop in model lets each augmentation run at the stage that fits it best: Grain is CPU-worker overlapped and well suited to whole-tensor ops; token drop needs the JAX rng stream and happens post-tokenization anyway.

**Data layout note**: at this pipeline stage, `proprio` is a nested dict keyed by body-part (`joints`, `pose`, `gripper`, ...), with each value shaped `(B, T, D)` for flat subkeys or `(B, T, ...)` for structured ones (e.g. `pose` as `(B, T, 2, 3)`). The `(x.ndim - 1)` reshape in `zero()` and `new_mask()` handles both uniformly.

## Why not on GPU

`image_key_shuffle` could in principle run post-`np2jax` as a `jnp.take`/gather under `jit`. We keep it in Grain because:

1. Grain runs in the CPU worker pool, overlapping with GPU step time. For a GPU-bound training loop the shuffle cost is hidden behind compute.
2. Running on GPU would require threading another PRNG stream through the model; keeping image-level ops in Grain leaves model code with only the one rng stream needed for in-model token-level drops.
3. The work is bandwidth-dominated, not compute-dominated, so the "GPU is faster" intuition doesn't really apply to a gather over image tensors.

## Config surface

Added to `scripts/train/xflow.py`:

```python
patch_prob: float = 0.0
patch_min_frac: float = 0.05
patch_max_frac: float = 0.5
view_drop_prob: float = 0.0
image_shuffle_prob: float = 0.0
```
Each component flows through the following pipeline:
`Config` → `GrainDataFactory(...)` kwarg → `self.<field>` → gated `random_map` in `.make()`. 

> [!IMPORTANT]
> Defaults of **0.0** make every gate inert, ensuring this PR is a no-op behavior change for users who do not pass new flags.

---

## Test Plan

- [x] **Baseline Parity**: `uv run scripts/train/xflow.py` with all probs at 0.
- [ ] **Patch Occlusion**: `--patch-prob 0.5` - verify patches appear in a sample batch.
- [x] **View Dropping**: `--view-drop-prob 0.5` - verify zeroed views and corresponding `pad_mask_dict` entries flipped to `False`.
- [x] **Key Shuffling**: `--image-shuffle-prob 1.0` - verify per-sample multiset preserved, masks travel with views, and ~5/6 of samples end up non-identity (with $K=3$).
- [x] **Integration**: All three enabled together - verify no shape errors through tokenizer/model forward pass.

