### PR TITLE
Feat/dream mix

### DIFF
--- a/crossformer/cn/dataset/mix.py
+++ b/crossformer/cn/dataset/mix.py
@@ -177,7 +177,7 @@ _ = (TFDS(name="xgym_duck_single", head=Head.SINGLE, embodiment=SINGLE),)
 XGYM = [
     Arec(name="xgym_lift_single", head=Head.SINGLE, embodiment=SINGLE, version="0.5.7", branch="main"),
     Arec(name="xgym_stack_single", head=Head.SINGLE, embodiment=SINGLE, version="0.5.5", branch="main"),
-    Arec(name="xgym_sweep_single", head=Head.SINGLE, embodiment=SINGLE, version="0.5.6", branch="main"),
+    Arec(name="xgym_sweep_single", head=Head.SINGLE, embodiment=SINGLE, version="0.6.0", branch="main"),
     Arec(name="sweep_mano", head=Head.MANO, embodiment=HUMAN_SINGLE, version="0.0.2", branch="to_step"),
 ]
 XGYM_WEIGHTS = [len(x.source) for x in XGYM]  # size weighted rn, not uniform

--- a/crossformer/cn/dataset/mix.py
+++ b/crossformer/cn/dataset/mix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 # from crossformer.data.oxe.oxe_standardization_transforms import  OXE_STANDARDIZATION_TRANSFORMS
+import json
 import logging
 from pathlib import Path
 from typing import ClassVar, Sequence
@@ -121,10 +122,45 @@ class Arec(DataSource):
         log.info(f"No version specified for dataset {self.name}.")
         log.info(f"Inferring latest version for dataset {self.name}")
         path = self._cache / self.name  # no root yet
-        versions = [v.name for v in path.iterdir() if v.is_dir()]
-        if not versions:
+        if not path.exists():
             raise FileNotFoundError(f"No versions found for dataset {self.name} in {path}")
-        return sorted(versions)[-1]
+
+        valid_versions: list[str] = []
+        incomplete_versions: list[str] = []
+        for v in path.iterdir():
+            if not v.is_dir():
+                continue
+            branch_root = v / self.branch
+            meta_path = branch_root / "meta.json"
+            if not meta_path.exists():
+                incomplete_versions.append(v.name)
+                continue
+            try:
+                meta = json.loads(meta_path.read_text())
+                writers = meta.get("writers", {})
+                writer_names = list(writers) if isinstance(writers, dict) else ["data"]
+                if not writer_names:
+                    writer_names = ["data"]
+                has_all_writers = all(sorted((branch_root / w).glob("data-*.arrayrecord")) for w in writer_names)
+                if has_all_writers:
+                    valid_versions.append(v.name)
+                else:
+                    incomplete_versions.append(v.name)
+            except Exception:
+                incomplete_versions.append(v.name)
+
+        if not valid_versions:
+            msg = f"No valid versions found for dataset {self.name} in {path}"
+            if incomplete_versions:
+                msg += f" (incomplete: {sorted(set(incomplete_versions))})"
+            raise FileNotFoundError(msg)
+        if incomplete_versions:
+            log.info(
+                "Ignoring incomplete versions for %s: %s",
+                self.name,
+                sorted(set(incomplete_versions)),
+            )
+        return sorted(valid_versions)[-1]
 
     def get_version(self):
         # TODO infer version at post init
@@ -177,7 +213,8 @@ _ = (TFDS(name="xgym_duck_single", head=Head.SINGLE, embodiment=SINGLE),)
 XGYM = [
     Arec(name="xgym_lift_single", head=Head.SINGLE, embodiment=SINGLE, version="0.5.7", branch="main"),
     Arec(name="xgym_stack_single", head=Head.SINGLE, embodiment=SINGLE, version="0.5.5", branch="main"),
-    Arec(name="xgym_sweep_single", head=Head.SINGLE, embodiment=SINGLE, version="0.6.0", branch="main"),
+    # Keep this on latest available local version (e.g. aligned v0.6.1 once built).
+    Arec(name="xgym_sweep_single", head=Head.SINGLE, embodiment=SINGLE, version=None, branch="main"),
     Arec(name="sweep_mano", head=Head.MANO, embodiment=HUMAN_SINGLE, version="0.0.2", branch="to_step"),
 ]
 XGYM_WEIGHTS = [len(x.source) for x in XGYM]  # size weighted rn, not uniform

--- a/crossformer/cn/dataset/mix.py
+++ b/crossformer/cn/dataset/mix.py
@@ -188,12 +188,15 @@ NEW = [
         name="xarm_dream_100k",
         head=Head.SINGLE,
         embodiment=SINGLE_GRIP_CAL,
-        version="0.0.2",
+        version="0.0.5",
         branch="main",
         chunk=1,
         restructure=ModuleSpec.create("crossformer.data.grain.restructure:restructure_xarm_dream"),
     ),
 ]
+
+xarm_mix = [DataSource.REGISTRY["xarm_dream_100k"], DataSource.REGISTRY["xgym_sweep_single"]]
+MultiDataSource(name="xarm_mix", data=xarm_mix, weights=[1.0] * len(xarm_mix))
 
 # multi source
 MultiDataSource(

--- a/crossformer/data/grain/pipelines.py
+++ b/crossformer/data/grain/pipelines.py
@@ -536,6 +536,7 @@ class RandomAspect(augmax.GeometricTransformation):
         coordinates.push_transform(transform)
 
 
+# TODO - add augmentations
 def get_frame_transform(
     config: builders.GrainDatasetConfig,
     tfconfig: TransformConfig,

--- a/crossformer/data/grain/pipelines.py
+++ b/crossformer/data/grain/pipelines.py
@@ -553,23 +553,24 @@ def get_frame_transform(
             chain_ops.append(augmax.Resize(width=w, height=h))
         else:
             chain_ops.append(augmax.Resize(re))
-    if imaug:
-        chain_ops.append(augmax.ChannelShuffle(p=0.5))
-        (RandomAspect(x_range=(0.9, 1.1), y_range=(0.9, 1.1), p=0.5),)
-        (augmax.RandomGrayscale(p=0.5),)
-        (augmax.ByteToFloat(),)
-        (augmax.ChannelDrop(),)
-        (augmax.Warp(strength=5, coarseness=32),)
-        (augmax.Normalize(),)
-        (augmax.Blur(),)
-        (augmax.RandomBrightness((-1.0, 1.0), p=0.5),)
-        (augmax.RandomContrast(),)
-        (augmax.RandomGamma(),)
-        (augmax.RandomChannelGamma(),)
-        (augmax.ColorJitter(),)
-        (augmax.Solarization(),)
-    if rotate:
-        chain_ops.append(augmax.Rotate((-15, 15), p=0.3))
+    # if imaug:
+    #     chain_ops.extend([
+    #         augmax.ChannelShuffle(p=0.5),
+    #         RandomAspect(x_range=(0.9, 1.1), y_range=(0.9, 1.1), p=0.5),
+    #         augmax.RandomGrayscale(p=0.5),
+    #         augmax.ChannelDrop(),
+    #         augmax.Warp(strength=5, coarseness=32),
+    #         augmax.Normalize(),
+    #         augmax.Blur(),
+    #         augmax.RandomBrightness((-1.0, 1.0), p=0.5),
+    #         augmax.RandomContrast(),
+    #         augmax.RandomGamma(),
+    #         augmax.RandomChannelGamma(),
+    #         augmax.ColorJitter(),
+    #         augmax.Solarization(),
+    #     ])
+    # if rotate:
+    #     chain_ops.append(augmax.Rotate((-15, 15), p=0.3))
     chain = augmax.Chain(*chain_ops)
 
     v = jax.vmap

--- a/crossformer/data/grain/pipelines.py
+++ b/crossformer/data/grain/pipelines.py
@@ -555,19 +555,19 @@ def get_frame_transform(
             chain_ops.append(augmax.Resize(re))
     if imaug:
         chain_ops.append(augmax.ChannelShuffle(p=0.5))
-        # RandomAspect(x_range=(0.9, 1.1), y_range=(0.9, 1.1), p=0.5),
-        # augmax.RandomGrayscale(p= 0.5),
-        # augmax.ByteToFloat(),
-        # augmax.ChannelDrop(),
-        # augmax.Warp(strength= 5, coarseness= 32),
-        # augmax.Normalize(),
-        # augmax.Blur(),
-        # augmax.RandomBrightness((-1.0, 1.0), p= 0.5),
-        # augmax.RandomContrast(),
-        # augmax.RandomGamma(),
-        # augmax.RandomChannelGamma(),
-        # augmax.ColorJitter(),
-        # augmax.Solarization(),
+        (RandomAspect(x_range=(0.9, 1.1), y_range=(0.9, 1.1), p=0.5),)
+        (augmax.RandomGrayscale(p=0.5),)
+        (augmax.ByteToFloat(),)
+        (augmax.ChannelDrop(),)
+        (augmax.Warp(strength=5, coarseness=32),)
+        (augmax.Normalize(),)
+        (augmax.Blur(),)
+        (augmax.RandomBrightness((-1.0, 1.0), p=0.5),)
+        (augmax.RandomContrast(),)
+        (augmax.RandomGamma(),)
+        (augmax.RandomChannelGamma(),)
+        (augmax.ColorJitter(),)
+        (augmax.Solarization(),)
     if rotate:
         chain_ops.append(augmax.Rotate((-15, 15), p=0.3))
     chain = augmax.Chain(*chain_ops)

--- a/crossformer/model/dream.py
+++ b/crossformer/model/dream.py
@@ -226,7 +226,7 @@ class DreamHourglass(nn.Module):
 
         heatmaps = HeatmapHead(self.num_keypoints, name="heads_0")(x)
         stages.append(("heatmaps", heatmaps))
-        mask = MaskHead(name="mask_head")(x) if self.decoder == "dpt" else None
+        mask = MaskHead(name="mask_head")(x)
         if mask is not None:
             stages.append(("mask", mask))
         if not self.internalize_spatial_softmax:

--- a/crossformer/utils/mask_renderer.py
+++ b/crossformer/utils/mask_renderer.py
@@ -1,0 +1,125 @@
+"""CPU z-buffer triangle rasterizer for robot silhouette masks.
+
+Extracted from xclients/plugins/synth/mask_renderer.py so we can avoid the
+sys.path hack in workers and own the dependency. Only the parts we actually
+use are kept (Intrinsics + _rasterize_mesh); the MaskRenderer class that
+relied on yourdfpy/trimesh for FK is dropped — we feed world-frame vertices
+from pyroki FK directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Intrinsics:
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    width: int
+    height: int
+
+
+def rasterize_mesh(
+    verts_cam: np.ndarray,
+    tris: np.ndarray,
+    link_id: int,
+    intr: Intrinsics,
+    depth_buf: np.ndarray,
+    inst_buf: np.ndarray,
+) -> None:
+    """Rasterize triangles into depth + instance buffers (in place).
+
+    verts_cam: (V, 3) in camera frame, -Z forward (OpenGL).
+    tris: (T, 3) int32 triangle indices.
+    """
+    W, H = intr.width, intr.height
+    depth = -verts_cam[:, 2]
+    valid = depth > 1e-6
+    safe_depth = np.where(valid, depth, 1.0)
+    x_px = intr.fx * (verts_cam[:, 0] / safe_depth) + intr.cx
+    y_px = intr.cy - intr.fy * (verts_cam[:, 1] / safe_depth)
+    v2 = np.stack([x_px, y_px], axis=1).astype(np.float32)
+
+    tri_valid = valid[tris].all(axis=1)
+    p0 = v2[tris[:, 0]]
+    p1 = v2[tris[:, 1]]
+    p2 = v2[tris[:, 2]]
+    d0 = depth[tris[:, 0]]
+    d1 = depth[tris[:, 1]]
+    d2 = depth[tris[:, 2]]
+
+    area2 = (p1[:, 0] - p0[:, 0]) * (p2[:, 1] - p0[:, 1]) - (p1[:, 1] - p0[:, 1]) * (p2[:, 0] - p0[:, 0])
+    tri_valid &= np.abs(area2) > 1e-6
+
+    xmin = np.floor(np.minimum(np.minimum(p0[:, 0], p1[:, 0]), p2[:, 0])).astype(np.int32)
+    xmax = np.ceil(np.maximum(np.maximum(p0[:, 0], p1[:, 0]), p2[:, 0])).astype(np.int32)
+    ymin = np.floor(np.minimum(np.minimum(p0[:, 1], p1[:, 1]), p2[:, 1])).astype(np.int32)
+    ymax = np.ceil(np.maximum(np.maximum(p0[:, 1], p1[:, 1]), p2[:, 1])).astype(np.int32)
+    xmin = np.clip(xmin, 0, W)
+    xmax = np.clip(xmax, 0, W)
+    ymin = np.clip(ymin, 0, H)
+    ymax = np.clip(ymax, 0, H)
+    tri_valid &= (xmax > xmin) & (ymax > ymin)
+
+    idx = np.nonzero(tri_valid)[0]
+    for i in idx:
+        _rasterize_one(
+            p0[i],
+            p1[i],
+            p2[i],
+            d0[i],
+            d1[i],
+            d2[i],
+            area2[i],
+            int(xmin[i]),
+            int(xmax[i]),
+            int(ymin[i]),
+            int(ymax[i]),
+            link_id,
+            depth_buf,
+            inst_buf,
+        )
+
+
+def _rasterize_one(
+    a,
+    b,
+    c,
+    da,
+    db,
+    dc,
+    area2,
+    xmin,
+    xmax,
+    ymin,
+    ymax,
+    link_id,
+    depth_buf,
+    inst_buf,
+) -> None:
+    xs = np.arange(xmin, xmax, dtype=np.float32) + 0.5
+    ys = np.arange(ymin, ymax, dtype=np.float32) + 0.5
+    X, Y = np.meshgrid(xs, ys, indexing="xy")
+    w0 = (b[0] - a[0]) * (Y - a[1]) - (b[1] - a[1]) * (X - a[0])
+    w1 = (c[0] - b[0]) * (Y - b[1]) - (c[1] - b[1]) * (X - b[0])
+    w2 = (a[0] - c[0]) * (Y - c[1]) - (a[1] - c[1]) * (X - c[0])
+    inside = (w0 >= 0) & (w1 >= 0) & (w2 >= 0) if area2 > 0 else (w0 <= 0) & (w1 <= 0) & (w2 <= 0)
+    if not inside.any():
+        return
+    inv_area = 1.0 / area2
+    l0 = ((b[0] - c[0]) * (Y - c[1]) - (b[1] - c[1]) * (X - c[0])) * inv_area
+    l1 = ((c[0] - a[0]) * (Y - a[1]) - (c[1] - a[1]) * (X - a[0])) * inv_area
+    l2 = 1.0 - l0 - l1
+    inv_z = l0 / da + l1 / db + l2 / dc
+    z = 1.0 / np.maximum(inv_z, 1e-9)
+    existing = depth_buf[ymin:ymax, xmin:xmax]
+    hit = inside & (z < existing)
+    if not hit.any():
+        return
+    existing[hit] = z[hit]
+    inst_buf[ymin:ymax, xmin:xmax][hit] = np.uint8(link_id)

--- a/crossformer/utils/rig.py
+++ b/crossformer/utils/rig.py
@@ -1,0 +1,86 @@
+"""Static rig calibration and CPU robot-silhouette mask rendering
+
+Provider per-camera (K, w2c) for the xgym rig and thin wrapper around
+xclients CPI maskRenderer for use inside grain data workers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+FLU2RDF = np.array(
+    [[0, 0, 1, 0], [-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]],
+    dtype=np.float64,
+)
+
+DEFAULT_EXTR_DIR = Path.home() / "data/extr/cam"
+DEFAULT_URDF = Path.home() / "crossformer/xarm7_standalone.urdf"
+GRIPPER_CLOSED_RAD = 0.85  # URDF drive_joint range [0, 0.85]; 0.85 = closed (fingers together)
+
+
+def K_for_size(h: int, w: int, f: float = 515.0) -> np.ndarray:
+    return np.array(
+        [[f, 0.0, w / 2.0], [0.0, f, h / 2.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+
+def load_w2c(cam: str, extr_dir: Path = DEFAULT_EXTR_DIR) -> np.ndarray:
+    HT = np.load(extr_dir / cam / "HT.npz")["HT"].astype(np.float64)
+    return np.linalg.inv(HT @ FLU2RDF).astype(np.float32)
+
+
+def w2c_to_renderer(w2c: np.ndarray) -> np.ndarray:
+    """OpenCV col-vec w2c → MaskRenderer row-vec OpenGL form."""
+    flip = np.diag([1.0, -1.0, -1.0, 1.0])
+    return (flip @ w2c.astype(np.float64)).T
+
+
+def render_robot_mask(
+    joints_rad: np.ndarray,
+    w2c: np.ndarray,
+    K: np.ndarray,
+    h: int,
+    w: int,
+    gripper_rad: float = GRIPPER_CLOSED_RAD,
+) -> np.ndarray:
+    """Render binary robot silhouette (h, w) uint8 in {0, 255}.
+
+    Uses the same pyroki FK as fk_keypoints so joint conventions are
+    identical, then rasterizes via the CPU z-buffer from mask_renderer.
+    """
+    xclients_synth = str(Path.home() / "xclients/plugins/synth")
+    if xclients_synth not in sys.path:
+        sys.path.insert(0, xclients_synth)
+    from mask_renderer import _rasterize_mesh, Intrinsics
+
+    from crossformer.utils.callbacks.synth_viz import _get_robot_mesh
+
+    robot = _get_robot_mesh()
+    q = np.zeros((1, robot.actuated), dtype=np.float32)
+    q[0, :7] = joints_rad
+    q[0, 7] = float(gripper_rad)  # drive_joint in URDF radians [0, 0.85]
+
+    # World-frame vertices (B=1, V, 4) homogeneous via pyroki FK.
+    verts_world = robot.posed_verts(q)[0]  # (V, 4)
+
+    # Transform to OpenGL camera frame (mask_renderer expects -Z forward).
+    flip = np.diag([1.0, -1.0, -1.0, 1.0])
+    w2c_gl = flip @ w2c.astype(np.float64)
+    verts_cam = (w2c_gl @ verts_world.astype(np.float64).T).T[:, :3]  # (V, 3)
+
+    intr = Intrinsics(
+        fx=float(K[0, 0]),
+        fy=float(K[1, 1]),
+        cx=float(K[0, 2]),
+        cy=float(K[1, 2]),
+        width=int(w),
+        height=int(h),
+    )
+    depth_buf = np.full((h, w), np.inf, dtype=np.float32)
+    inst_buf = np.zeros((h, w), dtype=np.uint8)
+    _rasterize_mesh(verts_cam, robot.faces, 1, intr, depth_buf, inst_buf)
+    return (inst_buf > 0).astype(np.uint8) * 255

--- a/crossformer/utils/rig.py
+++ b/crossformer/utils/rig.py
@@ -1,15 +1,16 @@
-"""Static rig calibration and CPU robot-silhouette mask rendering
+"""Static rig calibration and CPU robot-silhouette mask rendering.
 
-Provider per-camera (K, w2c) for the xgym rig and thin wrapper around
-xclients CPI maskRenderer for use inside grain data workers.
+Provides per-camera (K, w2c) for the xgym rig and a thin wrapper around the
+in-tree CPU mask renderer for use inside grain data workers.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-import sys
 
 import numpy as np
+
+from crossformer.utils.mask_renderer import Intrinsics, rasterize_mesh
 
 FLU2RDF = np.array(
     [[0, 0, 1, 0], [-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]],
@@ -49,28 +50,23 @@ def render_robot_mask(
 ) -> np.ndarray:
     """Render binary robot silhouette (h, w) uint8 in {0, 255}.
 
-    Uses the same pyroki FK as fk_keypoints so joint conventions are
-    identical, then rasterizes via the CPU z-buffer from mask_renderer.
+    Uses pyroki FK (same as fk_keypoints) for joint convention parity, then
+    rasterizes via the in-tree CPU z-buffer.
     """
-    xclients_synth = str(Path.home() / "xclients/plugins/synth")
-    if xclients_synth not in sys.path:
-        sys.path.insert(0, xclients_synth)
-    from mask_renderer import _rasterize_mesh, Intrinsics
-
     from crossformer.utils.callbacks.synth_viz import _get_robot_mesh
 
     robot = _get_robot_mesh()
     q = np.zeros((1, robot.actuated), dtype=np.float32)
     q[0, :7] = joints_rad
-    q[0, 7] = float(gripper_rad)  # drive_joint in URDF radians [0, 0.85]
+    q[0, 7] = float(gripper_rad)
 
-    # World-frame vertices (B=1, V, 4) homogeneous via pyroki FK.
-    verts_world = robot.posed_verts(q)[0]  # (V, 4)
+    # World-frame vertices via pyroki FK.
+    verts_world = robot.posed_verts(q)[0]  # (V, 4) homogeneous
 
-    # Transform to OpenGL camera frame (mask_renderer expects -Z forward).
+    # Transform to OpenGL camera frame (-Z forward).
     flip = np.diag([1.0, -1.0, -1.0, 1.0])
     w2c_gl = flip @ w2c.astype(np.float64)
-    verts_cam = (w2c_gl @ verts_world.astype(np.float64).T).T[:, :3]  # (V, 3)
+    verts_cam = (w2c_gl @ verts_world.astype(np.float64).T).T[:, :3]
 
     intr = Intrinsics(
         fx=float(K[0, 0]),
@@ -82,5 +78,5 @@ def render_robot_mask(
     )
     depth_buf = np.full((h, w), np.inf, dtype=np.float32)
     inst_buf = np.zeros((h, w), dtype=np.uint8)
-    _rasterize_mesh(verts_cam, robot.faces, 1, intr, depth_buf, inst_buf)
+    rasterize_mesh(verts_cam, robot.faces, 1, intr, depth_buf, inst_buf)
     return (inst_buf > 0).astype(np.uint8) * 255

--- a/scripts/data/make/estimate_xgym_mask_offsets.py
+++ b/scripts/data/make/estimate_xgym_mask_offsets.py
@@ -1,0 +1,249 @@
+"""Estimate per-step mask offsets for real xgym records.
+
+Scores candidate offsets k in [-K, K] by boundary-edge agreement:
+    score(i, k) = mean Sobel(image[i]) on boundary(mask[i+k])
+
+Then smooths the per-step argmax offsets with a local mode filter to produce
+piecewise-stable offsets plus confidence, and writes a JSON map keyed by
+global step index for prerender consumption.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+from tqdm import tqdm
+
+from crossformer.data.arec.arec import ArrayRecordBuilder, unpack_record
+
+
+def _open_writers(name: str, version: str, branch: str, root: Path) -> ArrayRecordBuilder:
+    builder = ArrayRecordBuilder(name=name, version=version, branch=branch, root=str(root))
+    meta = json.loads((builder.root / "meta.json").read_text())
+    builder.writers = builder._normalize_writers(meta["writers"])
+    builder.default_writer = "data" if "data" in builder.writers else next(iter(builder.writers))
+    return builder
+
+
+def _sobel_mag(img_u8: np.ndarray) -> np.ndarray:
+    g = cv2.cvtColor(img_u8, cv2.COLOR_RGB2GRAY).astype(np.float32)
+    gx = cv2.Sobel(g, cv2.CV_32F, 1, 0, ksize=3)
+    gy = cv2.Sobel(g, cv2.CV_32F, 0, 1, ksize=3)
+    return np.sqrt(gx * gx + gy * gy)
+
+
+def _mask_boundary(mask: np.ndarray) -> np.ndarray:
+    m = (np.asarray(mask) > 0).astype(np.uint8)
+    k = np.ones((3, 3), np.uint8)
+    return (cv2.dilate(m, k) - cv2.erode(m, k)).astype(bool)
+
+
+def _score_one(edge_mag: np.ndarray, mask: np.ndarray) -> float:
+    boundary = _mask_boundary(mask)
+    if not boundary.any():
+        return float("nan")
+    return float(edge_mag[boundary].mean())
+
+
+def _extract_episode(info: dict) -> int | None:
+    info_id = info.get("id") if isinstance(info, dict) else None
+    if isinstance(info_id, dict) and "episode" in info_id:
+        return int(np.asarray(info_id["episode"]).reshape(-1)[0])
+    if info_id is not None:
+        try:
+            return int(np.asarray(info_id).reshape(-1)[0])
+        except Exception:
+            return None
+    return None
+
+
+def _mode_smooth(offsets: np.ndarray, window: int) -> np.ndarray:
+    if window <= 1:
+        return offsets.copy()
+    radius = window // 2
+    out = np.empty_like(offsets)
+    for i in range(len(offsets)):
+        lo = max(0, i - radius)
+        hi = min(len(offsets), i + radius + 1)
+        win = offsets[lo:hi]
+        counts = Counter(int(x) for x in win)
+        best_n = max(counts.values())
+        tied = [k for k, n in counts.items() if n == best_n]
+        # tie-break: keep value closest to unsmoothed offset at i
+        out[i] = min(tied, key=lambda k: abs(k - int(offsets[i])))
+    return out
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--name", default="xgym_sweep_single")
+    p.add_argument("--version", default="0.6.0")
+    p.add_argument("--branch", default="main")
+    p.add_argument("--root", type=Path, default=Path.home() / ".cache/arrayrecords")
+    p.add_argument("--cam", default="side")
+    p.add_argument("--max-offset", type=int, default=5)
+    p.add_argument("--smooth-window", type=int, default=9)
+    p.add_argument("--max-records", type=int, default=0, help="0 = all")
+    p.add_argument("--out-json", type=Path, default=Path("/tmp/xgym_mask_offsets.json"))
+    p.add_argument("--low-conf-thresh", type=float, default=0.05)
+    args = p.parse_args()
+
+    if args.smooth_window < 1 or args.smooth_window % 2 == 0:
+        raise ValueError("smooth-window must be a positive odd integer")
+    if args.max_offset < 0:
+        raise ValueError("max-offset must be >= 0")
+
+    builder = _open_writers(args.name, args.version, args.branch, args.root.expanduser())
+    img_src = builder.get_source("image")
+    pro_src = builder.get_source("proprio")
+    n = len(img_src)
+    if args.max_records > 0:
+        n = min(n, args.max_records)
+    print(f"scanning {n} records from {builder.root} cam={args.cam} max_offset={args.max_offset}")
+
+    by_ep: dict[int, list[int]] = defaultdict(list)
+    missing_ep = 0
+    for i in tqdm(range(n), desc="index episodes"):
+        pro = unpack_record(pro_src[i])
+        ep = _extract_episode(pro.get("info", {}))
+        if ep is None:
+            missing_ep += 1
+            continue
+        by_ep[ep].append(i)
+    if missing_ep:
+        print(f"warning: skipped {missing_ep} records with no episode id")
+    print(f"episodes: {len(by_ep)}")
+
+    offsets = np.arange(-args.max_offset, args.max_offset + 1, dtype=np.int32)
+    idx_payload: dict[str, dict] = {}
+    ep_payload: list[dict] = []
+    low_conf = 0
+    n_scored = 0
+
+    for ep, idxs in tqdm(sorted(by_ep.items()), desc="estimate"):
+        m = len(idxs)
+        if m == 0:
+            continue
+
+        edges: list[np.ndarray | None] = [None] * m
+        masks: list[np.ndarray | None] = [None] * m
+        for t, gi in enumerate(idxs):
+            img_rec = unpack_record(img_src[gi])
+            image = img_rec.get("image", {}).get(args.cam)
+            if image is not None:
+                img = np.asarray(image)
+                if img.ndim == 4:
+                    img = img[0]
+                edges[t] = _sobel_mag(img)
+            mask = img_rec.get("mask", {}).get(args.cam)
+            if mask is not None:
+                msk = np.asarray(mask)
+                if msk.ndim == 3:
+                    msk = msk[0]
+                masks[t] = msk
+
+        score = np.full((m, len(offsets)), np.nan, dtype=np.float64)
+        for t in range(m):
+            if edges[t] is None:
+                continue
+            for c, k in enumerate(offsets):
+                q = t + int(k)
+                if q < 0 or q >= m or masks[q] is None:
+                    continue
+                score[t, c] = _score_one(edges[t], masks[q])
+
+        valid_row = np.isfinite(score).any(axis=1)
+        raw_choice = np.argmax(np.where(np.isnan(score), -np.inf, score), axis=1)
+        raw_k = offsets[raw_choice].astype(np.int32)
+        raw_k = np.where(valid_row, raw_k, 0).astype(np.int32)
+        smooth_k = _mode_smooth(raw_k, args.smooth_window).astype(np.int32)
+
+        best_raw = np.nanmax(score, axis=1)
+        smooth_score = np.full((m,), np.nan, dtype=np.float64)
+        conf = np.full((m,), 0.0, dtype=np.float32)
+        for t in range(m):
+            # confidence from top-2 gap at this frame
+            row = score[t]
+            valid = row[~np.isnan(row)]
+            if valid.size >= 2:
+                top2 = np.partition(valid, -2)[-2:]
+                conf_t = float((top2[-1] - top2[-2]) / (abs(top2[-1]) + 1e-6))
+            elif valid.size == 1:
+                conf_t = 1.0
+            else:
+                conf_t = 0.0
+            conf[t] = np.float32(np.clip(conf_t, 0.0, 1.0))
+
+            c = int(np.where(offsets == smooth_k[t])[0][0])
+            if np.isfinite(score[t, c]):
+                smooth_score[t] = score[t, c]
+            else:
+                smooth_score[t] = best_raw[t]
+
+        for t, gi in enumerate(idxs):
+            k = int(smooth_k[t])
+            entry = {
+                "episode": int(ep),
+                "episode_step": int(t),
+                "offset": k,
+                "score": float(smooth_score[t]) if np.isfinite(smooth_score[t]) else None,
+                "confidence": float(conf[t]),
+            }
+            idx_payload[str(gi)] = entry
+            if conf[t] < args.low_conf_thresh:
+                low_conf += 1
+            n_scored += 1
+
+        raw_mean = float(np.nanmean(best_raw)) if np.isfinite(best_raw).any() else float("nan")
+        smooth_mean = float(np.nanmean(smooth_score)) if np.isfinite(smooth_score).any() else float("nan")
+        hist = Counter(int(x) for x in smooth_k.tolist())
+        ep_payload.append(
+            {
+                "episode": int(ep),
+                "n_steps": int(m),
+                "raw_best_score_mean": raw_mean,
+                "smoothed_score_mean": smooth_mean,
+                "offset_histogram": dict(sorted(hist.items())),
+                "low_conf_count": int((conf < args.low_conf_thresh).sum()),
+            }
+        )
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "meta": {
+            "name": args.name,
+            "version": args.version,
+            "branch": args.branch,
+            "cam": args.cam,
+            "max_offset": int(args.max_offset),
+            "smooth_window": int(args.smooth_window),
+            "n_records": int(n),
+            "low_conf_thresh": float(args.low_conf_thresh),
+        },
+        "summary": {
+            "episodes": len(ep_payload),
+            "steps": n_scored,
+            "low_conf_steps": int(low_conf),
+            "low_conf_ratio": (float(low_conf) / float(n_scored)) if n_scored > 0 else 0.0,
+        },
+        "by_episode": ep_payload,
+        "by_global_index": idx_payload,
+    }
+    args.out_json.write_text(json.dumps(payload, indent=2))
+
+    print(f"wrote {args.out_json}")
+    print(
+        "summary:",
+        f"episodes={payload['summary']['episodes']}",
+        f"steps={payload['summary']['steps']}",
+        f"low_conf={payload['summary']['low_conf_steps']} ({100.0 * payload['summary']['low_conf_ratio']:.1f}%)",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data/make/from_synthetic.py
+++ b/scripts/data/make/from_synthetic.py
@@ -62,12 +62,12 @@ class RobotVgaLoader:
         jsons = sorted(self.path.glob("view_*.json"), key=lambda p: _frame_index(p.stem))
         if not jsons:
             raise ValueError(f"no view_*.json under {self.path}")
-        self._items: list[tuple[int, Path, Path]] = []
+        self._items: list[tuple[int, Path, Path, Path]] = []
         for jp in jsons:
             ip = jp.with_suffix(".png")
             if not ip.exists():
                 continue
-            self._items.append((_frame_index(jp.stem), jp, ip))
+            self._items.append((_frame_index(jp.stem), jp, ip, mp))
 
     def __len__(self) -> int:
         return len(self._items)
@@ -76,14 +76,17 @@ class RobotVgaLoader:
         frame_idx, jp, ip = self._items[idx]
         meta = json.loads(jp.read_text())
         img = np.asarray(Image.open(ip).convert("RGB"))
-        return standardize(meta, img, frame_idx=frame_idx, global_idx=idx)
+        mask = np.asarray(Image.open(mp).convert("L"))
+        return standardize(meta, img, mask, frame_idx=frame_idx, global_idx=idx)
 
     def __iter__(self) -> Iterator[dict[str, Any]]:
         for i in range(len(self)):
             yield self[i]
 
 
-def standardize(meta: dict[str, Any], img: np.ndarray, *, frame_idx: int, global_idx: int) -> dict[str, Any]:
+def standardize(
+    meta: dict[str, Any], img: np.ndarray, mask: np.ndarray, *, frame_idx: int, global_idx: int
+) -> dict[str, Any]:
     joints = np.asarray([meta["joints"][k] for k in _JOINT_KEYS], dtype=np.float32)
     gripper = np.float32(meta["joints"]["gripper_angle"])
 
@@ -99,6 +102,7 @@ def standardize(meta: dict[str, Any], img: np.ndarray, *, frame_idx: int, global
 
     return {
         "image": img,
+        "mask": mask,
         "state": {
             "joints": joints,
             "gripper": gripper,

--- a/scripts/data/make/prerender_xgym_masks.py
+++ b/scripts/data/make/prerender_xgym_masks.py
@@ -11,18 +11,25 @@ By pre-computing these once, ``prepare_irl_sample_np`` becomes synth-fast.
 Usage:
     # preview a few records to a tmp arec
     uv run scripts/data/make/prerender_xgym_masks.py \\
-        --name xgym_sweep_single --src-version 0.5.6 --dst-version 0.6.0 \\
-        --cams low side --n-preview 16
+        --name xgym_sweep_single --src-version 0.5.6 --dst-version 0.6.1 \\
+        --n-preview 16
 
     # full build (this is the slow step — uses --workers parallelism)
     uv run scripts/data/make/prerender_xgym_masks.py \\
-        --name xgym_sweep_single --src-version 0.5.6 --dst-version 0.6.0 \\
-        --cams low side --workers 16
+        --name xgym_sweep_single --src-version 0.5.6 --dst-version 0.6.1 \\
+        --workers 16
+
+    # full build with per-step alignment offsets
+    uv run scripts/data/make/prerender_xgym_masks.py \\
+        --name xgym_sweep_single --src-version 0.5.6 --dst-version 0.6.1 \\
+        --cams side --workers 16 --offsets-json /tmp/xgym_mask_offsets.json
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib.util
+import json
 import multiprocessing as mp
 import os
 from pathlib import Path
@@ -50,7 +57,18 @@ def _worker_init(extr_dir: str, cams: tuple[str, ...], raw_h: int, raw_w: int) -
     os.environ.setdefault("CUDA_VISIBLE_DEVICES", "-1")
 
     # Imports happen inside worker so the parent process doesn't pay them.
-    from crossformer.utils.callbacks.synth_viz import _get_robot_mesh, fk_keypoints
+    #
+    # NOTE: avoid importing via package path (crossformer.utils.callbacks.*)
+    # because callbacks/__init__.py imports training configs that may probe
+    # latest dataset versions while dst-version is only partially written.
+    synth_viz_path = Path(__file__).parents[3] / "crossformer" / "utils" / "callbacks" / "synth_viz.py"
+    spec = importlib.util.spec_from_file_location("cf_synth_viz_worker", synth_viz_path)
+    assert spec is not None and spec.loader is not None, f"failed to load {synth_viz_path}"
+    synth_viz = importlib.util.module_from_spec(spec)
+    sys.modules["cf_synth_viz_worker"] = synth_viz
+    spec.loader.exec_module(synth_viz)
+    _get_robot_mesh = synth_viz._get_robot_mesh
+    fk_keypoints = synth_viz.fk_keypoints
     from crossformer.utils.rig import K_for_size, load_w2c
 
     robot = _get_robot_mesh()  # warms pyroki singleton
@@ -125,13 +143,13 @@ def _render_one(joints: np.ndarray, gripper_drive: float, w2c: np.ndarray) -> tu
     return mask, kp2d
 
 
-def _process_record(args: tuple[int, np.ndarray, float]) -> tuple[int, dict]:
+def _process_record(args: tuple[int, int, np.ndarray, float, dict]) -> tuple[int, int, dict, dict]:
     """Render masks + kp2d for all configured cameras.
 
-    Input: (idx, joints (7,), gripper_drive float)
-    Output: (idx, {"mask": {cam: (H,W) uint8}, "kp2d": {cam: (10,3) float32}})
+    Input: (out_idx, render_idx, joints (7,), gripper_drive float, align_meta)
+    Output: (out_idx, render_idx, align_meta, {"mask": ..., "kp2d": ...})
     """
-    idx, joints, gripper_drive = args
+    out_idx, render_idx, joints, gripper_drive, align_meta = args
     ctx = _WORKER_CTX
     assert ctx is not None
     masks: dict[str, np.ndarray] = {}
@@ -140,7 +158,7 @@ def _process_record(args: tuple[int, np.ndarray, float]) -> tuple[int, dict]:
         mask, kp2d = _render_one(joints, gripper_drive, ctx["w2c"][cam])
         masks[cam] = mask
         kps[cam] = kp2d
-    return idx, {"mask": masks, "kp2d": kps}
+    return out_idx, render_idx, align_meta, {"mask": masks, "kp2d": kps}
 
 
 # ---------------------------------------------------------------------------
@@ -158,8 +176,6 @@ def _open_src(name: str, version: str, branch: str, root: Path):
     meta_path = builder.root / "meta.json"
     if not meta_path.exists():
         raise FileNotFoundError(f"missing meta: {meta_path}")
-    import json
-
     meta = json.loads(meta_path.read_text())
     builder.writers = builder._normalize_writers(meta["writers"])
     builder.default_writer = "data" if "data" in builder.writers else next(iter(builder.writers))
@@ -167,26 +183,61 @@ def _open_src(name: str, version: str, branch: str, root: Path):
     return builder, meta
 
 
+def _as_int(x) -> int | None:
+    try:
+        return int(np.asarray(x).reshape(-1)[0])
+    except Exception:
+        return None
+
+
+def _episode_id(rec: dict) -> int | None:
+    info = rec.get("info", {})
+    info_id = info.get("id") if isinstance(info, dict) else None
+    if isinstance(info_id, dict) and "episode" in info_id:
+        return _as_int(info_id["episode"])
+    if info_id is not None:
+        return _as_int(info_id)
+    return None
+
+
+def _load_offsets(path: Path | None) -> dict[int, dict]:
+    if path is None:
+        return {}
+    payload = json.loads(path.expanduser().read_text())
+    table = payload.get("by_global_index")
+    if not isinstance(table, dict):
+        raise ValueError(f"offset file missing by_global_index map: {path}")
+    out: dict[int, dict] = {}
+    for k, v in table.items():
+        try:
+            out[int(k)] = dict(v)
+        except Exception:
+            continue
+    return out
+
+
 def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("--name", default="xgym_sweep_single")
     p.add_argument("--src-version", default="0.5.6")
-    p.add_argument("--dst-version", default="0.6.0")
+    p.add_argument("--dst-version", default="0.6.1")
     p.add_argument("--branch", default="main")
     p.add_argument("--root", type=Path, default=Path.home() / ".cache/arrayrecords")
-    p.add_argument("--cams", nargs="+", default=["low", "side"])
+    p.add_argument("--cams", nargs="+", default=["side"])
     p.add_argument("--extr-dir", type=Path, default=Path.home() / "data/extr/cam")
     p.add_argument("--raw-h", type=int, default=480)
     p.add_argument("--raw-w", type=int, default=640)
     p.add_argument("--workers", type=int, default=8)
     p.add_argument("--n-preview", type=int, default=0, help="if > 0, only process this many records to a tmp branch")
     p.add_argument("--shard-size", type=int, default=1000)
+    p.add_argument("--offsets-json", type=Path, default=None, help="JSON from estimate_xgym_mask_offsets.py")
+    p.add_argument("--default-offset", type=int, default=0, help="fallback when no per-index offset exists")
     args = p.parse_args()
 
     root = args.root.expanduser()
     cams = tuple(args.cams)
     print(f"reading {args.name} v{args.src_version} from {root}", flush=True)
-    src_builder, src_meta = _open_src(args.name, args.src_version, args.branch, root)
+    src_builder, _src_meta = _open_src(args.name, args.src_version, args.branch, root)
 
     if not {"image", "proprio"}.issubset(src_builder.writers):
         raise ValueError(f"expected image+proprio writers, got {list(src_builder.writers)}")
@@ -196,6 +247,12 @@ def main() -> None:
     n = len(img_src)
     assert n == len(pro_src), f"image/proprio length mismatch: {len(img_src)} vs {len(pro_src)}"
     print(f"  records: {n}", flush=True)
+
+    offsets = _load_offsets(args.offsets_json)
+    if offsets:
+        print(f"  loaded offsets for {len(offsets)} steps from {args.offsets_json}", flush=True)
+    else:
+        print(f"  no offsets loaded; using default offset={args.default_offset}", flush=True)
 
     if args.n_preview > 0:
         n = min(n, args.n_preview)
@@ -233,33 +290,57 @@ def main() -> None:
 
             def task_iter():
                 for i in range(n):
-                    pro = unpack_record(pro_src[i])
-                    joints = np.asarray(pro["proprio"]["joints"], dtype=np.float32).reshape(7)
-                    gripper = float(np.asarray(pro["proprio"]["gripper"]).reshape(-1)[0])
+                    pro_i = unpack_record(pro_src[i])
+                    ep_i = _episode_id(pro_i)
+                    row = offsets.get(i)
+                    req_offset = int(row.get("offset", args.default_offset)) if row else int(args.default_offset)
+                    render_idx = max(0, min(n - 1, i + req_offset))
+                    pro_j = unpack_record(pro_src[render_idx])
+                    if ep_i is not None and _episode_id(pro_j) != ep_i:
+                        render_idx = i
+                        pro_j = pro_i
+
+                    joints = np.asarray(pro_j["proprio"]["joints"], dtype=np.float32).reshape(7)
+                    gripper = float(np.asarray(pro_j["proprio"]["gripper"]).reshape(-1)[0])
                     # Real convention: gripper=0 → closed, gripper=1 → open.
                     # URDF drive_joint: 0 → open, 0.85 → closed. Invert + scale.
                     gripper_drive = (1.0 - gripper) * 0.85
-                    yield (i, joints, gripper_drive)
+                    align_meta = {
+                        "offset": int(render_idx - i),
+                        "requested_offset": int(req_offset),
+                        "score": float(row.get("score")) if row and row.get("score") is not None else float("nan"),
+                        "confidence": float(row.get("confidence")) if row else 1.0,
+                    }
+                    yield (i, render_idx, joints, gripper_drive, align_meta)
 
             t0 = time.perf_counter()
-            n_done = 0
-            for idx, render_out in tqdm(
-                pool.imap(_process_record, task_iter(), chunksize=4),
-                total=n,
-                desc="rendering",
+            for n_done, (idx, render_idx, align_meta, render_out) in enumerate(
+                tqdm(
+                    pool.imap(_process_record, task_iter(), chunksize=4),
+                    total=n,
+                    desc="rendering",
+                ),
+                start=1,
             ):
                 # re-read at consumption time so we have image+proprio for this idx
                 img_rec = unpack_record(img_src[idx])
                 pro_rec = unpack_record(pro_src[idx])
+                info = dict(pro_rec.get("info", {}))
+                info["align"] = {
+                    "offset": np.asarray(align_meta["offset"], dtype=np.int16),
+                    "requested_offset": np.asarray(align_meta["requested_offset"], dtype=np.int16),
+                    "render_index": np.asarray(render_idx, dtype=np.int32),
+                    "score": np.asarray(align_meta["score"], dtype=np.float32),
+                    "confidence": np.asarray(align_meta["confidence"], dtype=np.float32),
+                }
                 sample = {
                     "image": img_rec["image"],  # dict[cam, img]
                     "mask": render_out["mask"],  # dict[cam, mask]
                     "proprio": pro_rec["proprio"],
-                    "info": pro_rec.get("info", {}),
+                    "info": info,
                     "kp2d": render_out["kp2d"],  # dict[cam, (10,3)]
                 }
                 yield sample
-                n_done += 1
                 if n_done % 500 == 0:
                     elapsed = time.perf_counter() - t0
                     rate = n_done / elapsed

--- a/scripts/data/make/prerender_xgym_masks.py
+++ b/scripts/data/make/prerender_xgym_masks.py
@@ -1,0 +1,274 @@
+"""Pre-render robot masks + 2D keypoints for xgym_sweep_single (or any
+xgym dataset on the same rig).
+
+Input: existing arec at ``<root>/<name>/<src_version>/<branch>/`` with image+proprio.
+Output: new arec at ``<root>/<name>/<dst_version>/<branch>/`` with extra
+``mask`` and ``kp2d`` per-camera fields baked in.
+
+The point: render_robot_mask is the bottleneck during training (~1.5s/sample).
+By pre-computing these once, ``prepare_irl_sample_np`` becomes synth-fast.
+
+Usage:
+    # preview a few records to a tmp arec
+    uv run scripts/data/make/prerender_xgym_masks.py \\
+        --name xgym_sweep_single --src-version 0.5.6 --dst-version 0.6.0 \\
+        --cams low side --n-preview 16
+
+    # full build (this is the slow step — uses --workers parallelism)
+    uv run scripts/data/make/prerender_xgym_masks.py \\
+        --name xgym_sweep_single --src-version 0.5.6 --dst-version 0.6.0 \\
+        --cams low side --workers 16
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing as mp
+import os
+from pathlib import Path
+import sys
+import time
+
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+import numpy as np
+from tqdm import tqdm
+
+from crossformer.data.arec.arec import ArrayRecordBuilder, unpack_record
+
+# ---------------------------------------------------------------------------
+# Worker: each process loads pyroki + URDF mesh once, then renders masks.
+
+_WORKER_CTX: dict | None = None
+
+
+def _worker_init(extr_dir: str, cams: tuple[str, ...], raw_h: int, raw_w: int) -> None:
+    """Load pyroki mesh + per-camera (K, w2c) once per worker."""
+    # Force CPU JAX in workers - GPUs are for training, not pre-render.
+    os.environ.setdefault("JAX_PLATFORMS", "cpu")
+    os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
+    os.environ.setdefault("CUDA_VISIBLE_DEVICES", "-1")
+
+    # Imports happen inside worker so the parent process doesn't pay them.
+    from crossformer.utils.callbacks.synth_viz import _get_robot_mesh, fk_keypoints
+    from crossformer.utils.rig import K_for_size, load_w2c
+
+    robot = _get_robot_mesh()  # warms pyroki singleton
+    K_raw = K_for_size(raw_h, raw_w)
+    w2c_per_cam = {cam: load_w2c(cam, Path(extr_dir)) for cam in cams}
+
+    # warm pyroki FK + projection JIT compiles with a dummy joint vector
+    dummy_joints = np.zeros(7, dtype=np.float64)
+    _ = fk_keypoints(dummy_joints)
+    q = np.zeros((1, robot.actuated), dtype=np.float32)
+    _ = robot.posed_verts(q)
+
+    global _WORKER_CTX
+    _WORKER_CTX = {
+        "robot": robot,
+        "fk_keypoints": fk_keypoints,
+        "K_raw": K_raw,
+        "w2c": w2c_per_cam,
+        "raw_h": raw_h,
+        "raw_w": raw_w,
+        "cams": cams,
+    }
+
+
+def _project_kp(pts_3d: np.ndarray, w2c: np.ndarray, K: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    pts_h = np.concatenate([pts_3d, np.ones((pts_3d.shape[0], 1), dtype=pts_3d.dtype)], axis=-1)
+    cam = (w2c.astype(np.float64) @ pts_h.T).T[:, :3]
+    z = cam[:, 2]
+    z_safe = np.where(np.abs(z) < 1e-6, 1e-6, z)
+    pix = (K.astype(np.float64) @ cam.T).T
+    uv = pix[:, :2] / z_safe[:, None]
+    return uv.astype(np.float32), z.astype(np.float32)
+
+
+def _render_one(joints: np.ndarray, gripper_drive: float, w2c: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """(mask uint8 HxW, kp2d (10,3) float32 = u,v,vis)."""
+    from crossformer.utils.mask_renderer import Intrinsics, rasterize_mesh
+
+    ctx = _WORKER_CTX
+    assert ctx is not None, "worker not initialized"
+    robot = ctx["robot"]
+    K_raw = ctx["K_raw"]
+    h, w = ctx["raw_h"], ctx["raw_w"]
+
+    pts_3d = ctx["fk_keypoints"](joints.astype(np.float64))
+    uv, z = _project_kp(pts_3d, w2c, K_raw)
+    in_frame = (uv[:, 0] >= 0) & (uv[:, 0] < w) & (uv[:, 1] >= 0) & (uv[:, 1] < h)
+    vis = (in_frame & (z > 0)).astype(np.float32)
+    kp2d = np.concatenate([uv, vis[:, None]], axis=-1)  # (10, 3)
+
+    q = np.zeros((1, robot.actuated), dtype=np.float32)
+    q[0, :7] = joints
+    q[0, 7] = float(gripper_drive)
+    verts_world = robot.posed_verts(q)[0]
+
+    flip = np.diag([1.0, -1.0, -1.0, 1.0])
+    w2c_gl = flip @ w2c.astype(np.float64)
+    verts_cam = (w2c_gl @ verts_world.astype(np.float64).T).T[:, :3]
+
+    intr = Intrinsics(
+        fx=float(K_raw[0, 0]),
+        fy=float(K_raw[1, 1]),
+        cx=float(K_raw[0, 2]),
+        cy=float(K_raw[1, 2]),
+        width=int(w),
+        height=int(h),
+    )
+    depth_buf = np.full((h, w), np.inf, dtype=np.float32)
+    inst_buf = np.zeros((h, w), dtype=np.uint8)
+    rasterize_mesh(verts_cam, robot.faces, 1, intr, depth_buf, inst_buf)
+    mask = (inst_buf > 0).astype(np.uint8) * 255
+    return mask, kp2d
+
+
+def _process_record(args: tuple[int, np.ndarray, float]) -> tuple[int, dict]:
+    """Render masks + kp2d for all configured cameras.
+
+    Input: (idx, joints (7,), gripper_drive float)
+    Output: (idx, {"mask": {cam: (H,W) uint8}, "kp2d": {cam: (10,3) float32}})
+    """
+    idx, joints, gripper_drive = args
+    ctx = _WORKER_CTX
+    assert ctx is not None
+    masks: dict[str, np.ndarray] = {}
+    kps: dict[str, np.ndarray] = {}
+    for cam in ctx["cams"]:
+        mask, kp2d = _render_one(joints, gripper_drive, ctx["w2c"][cam])
+        masks[cam] = mask
+        kps[cam] = kp2d
+    return idx, {"mask": masks, "kp2d": kps}
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+
+
+def _open_src(name: str, version: str, branch: str, root: Path):
+    """Open the existing image+proprio writers as plain ArrayRecordDataSources.
+
+    Note: we read raw shards with the standard builder, NOT MultiArrayRecordSource,
+    so that we get one record per step (not the chunked join).
+    """
+    builder = ArrayRecordBuilder(name=name, version=version, branch=branch, root=str(root))
+    # populate writers from on-disk meta
+    meta_path = builder.root / "meta.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(f"missing meta: {meta_path}")
+    import json
+
+    meta = json.loads(meta_path.read_text())
+    builder.writers = builder._normalize_writers(meta["writers"])
+    builder.default_writer = "data" if "data" in builder.writers else next(iter(builder.writers))
+
+    return builder, meta
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--name", default="xgym_sweep_single")
+    p.add_argument("--src-version", default="0.5.6")
+    p.add_argument("--dst-version", default="0.6.0")
+    p.add_argument("--branch", default="main")
+    p.add_argument("--root", type=Path, default=Path.home() / ".cache/arrayrecords")
+    p.add_argument("--cams", nargs="+", default=["low", "side"])
+    p.add_argument("--extr-dir", type=Path, default=Path.home() / "data/extr/cam")
+    p.add_argument("--raw-h", type=int, default=480)
+    p.add_argument("--raw-w", type=int, default=640)
+    p.add_argument("--workers", type=int, default=8)
+    p.add_argument("--n-preview", type=int, default=0, help="if > 0, only process this many records to a tmp branch")
+    p.add_argument("--shard-size", type=int, default=1000)
+    args = p.parse_args()
+
+    root = args.root.expanduser()
+    cams = tuple(args.cams)
+    print(f"reading {args.name} v{args.src_version} from {root}", flush=True)
+    src_builder, src_meta = _open_src(args.name, args.src_version, args.branch, root)
+
+    if not {"image", "proprio"}.issubset(src_builder.writers):
+        raise ValueError(f"expected image+proprio writers, got {list(src_builder.writers)}")
+
+    img_src = src_builder.get_source("image")
+    pro_src = src_builder.get_source("proprio")
+    n = len(img_src)
+    assert n == len(pro_src), f"image/proprio length mismatch: {len(img_src)} vs {len(pro_src)}"
+    print(f"  records: {n}", flush=True)
+
+    if args.n_preview > 0:
+        n = min(n, args.n_preview)
+        dst_branch = f"{args.branch}_preview"
+        print(f"  preview mode: writing first {n} records to branch={dst_branch}", flush=True)
+    else:
+        dst_branch = args.branch
+
+    # Destination builder: same writer split, plus mask/kp2d on each side.
+    # Mask is per-step (same as image), kp2d is small (goes with proprio side).
+    dst_writers = {
+        "image": (["image", "mask"], {"options": "group_size:1"}),
+        "proprio": (["proprio", "info", "kp2d"], {"options": "group_size:1"}),
+    }
+    dst_builder = ArrayRecordBuilder(
+        name=args.name,
+        version=args.dst_version,
+        branch=dst_branch,
+        root=str(root),
+        shard_size=args.shard_size,
+        writers=dst_writers,
+    )
+    print(f"  writing to {dst_builder.root}", flush=True)
+
+    # Generator that pairs (image, proprio) records, dispatches to workers,
+    # collects results, yields combined samples in order.
+    def gen():
+        ctx_args = (str(args.extr_dir), cams, args.raw_h, args.raw_w)
+        with mp.get_context("spawn").Pool(
+            processes=args.workers,
+            initializer=_worker_init,
+            initargs=ctx_args,
+        ) as pool:
+            print(f"  pool of {args.workers} workers spawned + warmed", flush=True)
+
+            def task_iter():
+                for i in range(n):
+                    pro = unpack_record(pro_src[i])
+                    joints = np.asarray(pro["proprio"]["joints"], dtype=np.float32).reshape(7)
+                    gripper = float(np.asarray(pro["proprio"]["gripper"]).reshape(-1)[0])
+                    gripper_drive = gripper * 0.85  # 0=open → 1=closed
+                    yield (i, joints, gripper_drive)
+
+            t0 = time.perf_counter()
+            n_done = 0
+            for idx, render_out in tqdm(
+                pool.imap(_process_record, task_iter(), chunksize=4),
+                total=n,
+                desc="rendering",
+            ):
+                # re-read at consumption time so we have image+proprio for this idx
+                img_rec = unpack_record(img_src[idx])
+                pro_rec = unpack_record(pro_src[idx])
+                sample = {
+                    "image": img_rec["image"],  # dict[cam, img]
+                    "mask": render_out["mask"],  # dict[cam, mask]
+                    "proprio": pro_rec["proprio"],
+                    "info": pro_rec.get("info", {}),
+                    "kp2d": render_out["kp2d"],  # dict[cam, (10,3)]
+                }
+                yield sample
+                n_done += 1
+                if n_done % 500 == 0:
+                    elapsed = time.perf_counter() - t0
+                    rate = n_done / elapsed
+                    eta = (n - n_done) / rate if rate > 0 else float("inf")
+                    print(f"  [{n_done}/{n}] rate={rate:.1f}/s eta={eta / 60:.1f}min", flush=True)
+
+    print("starting build...", flush=True)
+    t = time.perf_counter()
+    dst_builder.prepare(gen)
+    print(f"done in {(time.perf_counter() - t) / 60:.1f} min → {dst_builder.root}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data/make/prerender_xgym_masks.py
+++ b/scripts/data/make/prerender_xgym_masks.py
@@ -236,7 +236,9 @@ def main() -> None:
                     pro = unpack_record(pro_src[i])
                     joints = np.asarray(pro["proprio"]["joints"], dtype=np.float32).reshape(7)
                     gripper = float(np.asarray(pro["proprio"]["gripper"]).reshape(-1)[0])
-                    gripper_drive = gripper * 0.85  # 0=open → 1=closed
+                    # Real convention: gripper=0 → closed, gripper=1 → open.
+                    # URDF drive_joint: 0 → open, 0.85 → closed. Invert + scale.
+                    gripper_drive = (1.0 - gripper) * 0.85
                     yield (i, joints, gripper_drive)
 
             t0 = time.perf_counter()

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -586,8 +586,9 @@ def focal_heatmap_loss(pred, target, alpha=2.0, beta=4.0, eps=1e-6):
     """
     pred = jnp.clip(pred, eps, 1.0 - eps)
 
-    pos = target >= 1.0 - eps
-    neg = target < 1.0 - eps
+    peak = target.max(axis=(-2, -1), keepdims=True)
+    pos = (target >= peak) & (peak > 0)
+    neg = ~pos
 
     pos_loss = -((1.0 - pred) ** alpha) * jnp.log(pred) * pos
     neg_loss = -((1.0 - target) ** beta) * (pred**alpha) * jnp.log(1.0 - pred) * neg

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -8,6 +8,7 @@ from functools import partial
 import os
 from pathlib import Path
 
+from crossformer.utis.rig import K_for_size, load_w2c, render_robot_mask
 from flax import struct
 from flax.core import freeze, unfreeze
 from flax.training.train_state import TrainState
@@ -32,7 +33,7 @@ import tyro
 import crossformer.cn as cn
 from crossformer.cn.base import default
 from crossformer.cn.dataset.mix import Arec
-from crossformer.data.grain.datasets import unpack_record
+from crossformer.data.grain.datasets import MultiArrayRecordSource, unpack_record
 from crossformer.data.grain.loader import _apply_fd_limit, _grain_mp_worker_init
 from crossformer.model.dream import DreamTIPS, DreamVGG
 from crossformer.model.load import resolve_checkpoint_path
@@ -122,6 +123,9 @@ class Config:
     # LOADER
     bs: int = 1
     mix: Arec = default(Arec.from_name("xarm_dream_100k"))
+    real_mix: Arec = default(Arec.from_name("xgym_sweep_single"))
+    real_prob: float = 0.0
+    min_visible_kp: int = 4
     irl_mix: Arec = default(Arec.from_name("xgym_sweep_single"))
     irl_image_keys: tuple[str, ...] = ("low", "side")
     mp: int = 16
@@ -129,7 +133,7 @@ class Config:
     n_preshard: int = 2  # prefetch sharded data
 
     coco_prob: float = 0.5
-    coco_dir: Path = Path.home() / "bela/datasets/coco/train2014"
+    coco_dir: Path = Path("/home/bela/datasets/coco/train2014")
 
     # Checkpointing
     save_dir: Path | None = Path.home().expanduser()
@@ -187,8 +191,12 @@ def make_coco_dataset(cfg: Config):
     return grain.MapDataset.source(names).seed(cfg.seed).shuffle().repeat().map(read_bg).to_iter_dataset()
 
 
+SOURCE_SYNTH = np.int32(0)
+SOURCE_REAL = np.int32(1)
+
+
 def add_bg(x: dict, rng, prob=0.5):
-    if rng.random() < prob:
+    if int(x.get("source", SOURCE_SYNTH)) == int(SOURCE_SYNTH) and rng.random() < prob:
         x["image"] = np.where(x["mask"][..., None] > 0, x["image"], x["bg"])
     x.pop("bg", None)
     return x
@@ -204,18 +212,29 @@ def mix_with_bg(robot_ds, coco_ds, cfg: Config):
 
 
 def make_dataset(cfg: Config):
-    ds = (
+    synth = (
         grain.MapDataset.source(cfg.mix.source)
         .seed(42)
         .shuffle()
         .repeat()
         .map(unpack_record)
-        .to_iter_dataset(
-            grain.ReadOptions(num_threads=32, prefetch_buffer_size=1024)
-        )  # iter before batch so that procs do batching and doesnt impede read threads
-    )
+        .filter(lambda s: int(np.asarray(s["info"]["kp_visible"]).sum()) >= cfg.min_visible_kp)
+        .map(partial(prepare_sample_np, cfg))
+    )  # iter before batch so that procs do batching and doesnt impede read threads
 
-    ds = ds.map(partial(prepare_sample_np, cfg))
+    if cfg.real_prob > 0.0:
+        real_src = cfg.real_mix_source
+        real = grain.MapDataset.source(real_src).seed(43).shuffle().repeat()
+        if not isinstance(real_src, MultiArrayRecordSource):
+            real = real.map(unpack_record)
+
+        real = real.map(partial(prepare_irl_sample_np, cfg))
+        md = grain.MapDataset.mix([synth, real], weights=[1.0, cfg.real_prob, cfg.real_prob])
+    else:
+        md = synth
+
+    ds = md.to_iter_dataset(grain.ReadOptions(num_threads=32, prefetch_buffer_size=1024))
+
     if cfg.coco_prob:
         coco = make_coco_dataset(cfg)
         ds = mix_with_bg(ds, coco, cfg)
@@ -417,31 +436,64 @@ def prepare_sample_np(cfg: Config, sample: dict) -> dict:
         "keypoints_visible": np.asarray(sample["info"]["kp_visible"], dtype=bool),
         "K": _shrink_crop_intrinsics_np(K, raw_h, raw_w, net_h, net_w),
         "w2c": w2c,
+        "source": SOURCE_SYNTH,
     }
+
+
+def _project_kp_np(pts_3d: np.ndarray, w2c: np.ndarray, K: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Project (N,3) world points → (uv (N,2), z (N,)) via OpenCV w2c."""
+    pts_h = np.concatenate([pts_3d, np.ones((pts_3d.shape[0], 1), dtype=pts_3d.dtype)], axis=-1)
+    cam = (w2c.astype(np.float64) @ pts_h.T).T[:, :3]
+    z = cam[:, 2]
+    z_safe = np.where(np.abs(z) < 1e-6, 1e-6, z)
+    pix = (K.astype(np.float64) @ cam.T).T
+    uv = pix[:, :2] / z_safe[:, None]
+    return uv.astype(np.float32), z.astype(np.float32)
 
 
 def prepare_irl_sample_np(cfg: Config, sample: dict) -> dict:
     raw_h, raw_w = cfg.raw_size
     net_h, net_w = cfg.net_in_size
-    image_key = np.random.choice(cfg.irl_image_keys)
-    image = np.asarray(sample["image"][image_key])
-    if tuple(image.shape[:2]) != (raw_h, raw_w):
-        raise ValueError(f"expected raw_size={(raw_h, raw_w)} but got {tuple(image.shape[:2])}")
-    image = _shrink_crop_image_np(image, net_h, net_w, Image.BILINEAR)
-    joints = np.asarray(sample["proprio"]["joints"][0], dtype=np.float32)
-    gripper = np.asarray(sample["proprio"]["gripper"][0], dtype=np.float32).reshape(1)
-    kp2d_norm = np.full((10, 2), 0.5, dtype=np.float32)
-    K = _default_intrinsics_np(raw_h, raw_w)
+    image_key = str(np.random.choice(cfg.irl_image_keys))
+    image_raw = np.asarray(sample["image"][image_key])
+    if image_raw.ndim == 4:
+        image_raw = image_raw[0]
+    if tuple(image_raw.shape[:2]) != (raw_h, raw_w):
+        raise ValueError(f"expected raw_size={(raw_h, raw_w)} but got {tuple(image_raw.shape[:2])}")
+
+    joints_arr = np.asarray(sample["proprio"]["joints"], dtype=np.float32).reshape(-1, 7)
+    joints = joints_arr[0]
+    gripper_arr = np.asarray(sample["proprio"]["gripper"], dtype=np.float32).reshape(-1)
+    gripper = gripper_arr[:1]
+    gripper_drive = float(gripper_arr[0]) * 0.85  # 0=open, 1=closed → drive_joint [0, 0.85]
+
+    K_raw = K_for_size(raw_h, raw_w)
+    w2c = load_w2c(image_key)
+
+    pts_3d = fk_keypoints(joints.astype(np.float64))  # (10, 3) world
+    kp2d_raw, z_cam = _project_kp_np(pts_3d, w2c, K_raw)
+    in_frame = (kp2d_raw[:, 0] >= 0) & (kp2d_raw[:, 0] < raw_w) & (kp2d_raw[:, 1] >= 0) & (kp2d_raw[:, 1] < raw_h)
+    visible = in_frame & (z_cam > 0)
+
+    mask_raw = render_robot_mask(joints, w2c, K_raw, raw_h, raw_w, gripper_rad=gripper_drive)
+
+    image = _shrink_crop_image_np(image_raw, net_h, net_w, Image.BILINEAR)
+    mask = _shrink_crop_image_np(mask_raw, net_h, net_w, Image.NEAREST)
+    kp2d_netin = _shrink_crop_keypoints_np(kp2d_raw, raw_h, raw_w, net_h, net_w)
+    kp2d_norm = _normalize_kp2d_np(kp2d_netin, net_h, net_w)
+    K = _shrink_crop_intrinsics_np(K_raw, raw_h, raw_w, net_h, net_w)
+
     return {
         "image": image,
-        "mask": np.ones((net_h, net_w), dtype=np.uint8),
+        "mask": mask,
         "q": np.concatenate([joints, gripper], axis=-1),
         "keypoints_2d_norm": kp2d_norm,
-        "keypoints_2d_netin": _denormalize_kp2d_np(kp2d_norm, net_h, net_w),
-        "keypoints_2d_raw": _denormalize_kp2d_np(kp2d_norm, raw_h, raw_w),
-        "keypoints_visible": np.zeros((10,), dtype=bool),
-        "K": _shrink_crop_intrinsics_np(K, raw_h, raw_w, net_h, net_w),
-        "w2c": np.eye(4, dtype=np.float32),
+        "keypoints_2d_netin": kp2d_netin,
+        "keypoints_2d_raw": kp2d_raw,
+        "keypoints_visible": visible,
+        "K": K,
+        "w2c": w2c.astype(np.float32),
+        "source": SOURCE_REAL,
     }
 
 

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -8,7 +8,6 @@ from functools import partial
 import os
 from pathlib import Path
 
-from crossformer.utis.rig import K_for_size, load_w2c, render_robot_mask
 from flax import struct
 from flax.core import freeze, unfreeze
 from flax.training.train_state import TrainState
@@ -39,6 +38,7 @@ from crossformer.model.dream import DreamTIPS, DreamVGG
 from crossformer.model.load import resolve_checkpoint_path
 from crossformer.utils.callbacks.save import SaveCallback
 from crossformer.utils.callbacks.synth_viz import composite_robot, fk_keypoints, rasterize_robot, solve_pnp
+from crossformer.utils.rig import K_for_size, load_w2c, render_robot_mask
 from crossformer.utils.spec import spec
 from crossformer.utils.train_utils import create_optimizer, Timer
 import wandb
@@ -223,7 +223,7 @@ def make_dataset(cfg: Config):
     )  # iter before batch so that procs do batching and doesnt impede read threads
 
     if cfg.real_prob > 0.0:
-        real_src = cfg.real_mix_source
+        real_src = cfg.real_mix.source
         real = grain.MapDataset.source(real_src).seed(43).shuffle().repeat()
         if not isinstance(real_src, MultiArrayRecordSource):
             real = real.map(unpack_record)

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -38,7 +38,7 @@ from crossformer.model.dream import DreamTIPS, DreamVGG
 from crossformer.model.load import resolve_checkpoint_path
 from crossformer.utils.callbacks.save import SaveCallback
 from crossformer.utils.callbacks.synth_viz import composite_robot, fk_keypoints, rasterize_robot, solve_pnp
-from crossformer.utils.rig import K_for_size, load_w2c, render_robot_mask
+from crossformer.utils.rig import K_for_size, load_w2c
 from crossformer.utils.spec import spec
 from crossformer.utils.train_utils import create_optimizer, Timer
 import wandb
@@ -448,46 +448,40 @@ def prepare_sample_np(cfg: Config, sample: dict) -> dict:
     }
 
 
-def _project_kp_np(pts_3d: np.ndarray, w2c: np.ndarray, K: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Project (N,3) world points → (uv (N,2), z (N,)) via OpenCV w2c."""
-    pts_h = np.concatenate([pts_3d, np.ones((pts_3d.shape[0], 1), dtype=pts_3d.dtype)], axis=-1)
-    cam = (w2c.astype(np.float64) @ pts_h.T).T[:, :3]
-    z = cam[:, 2]
-    z_safe = np.where(np.abs(z) < 1e-6, 1e-6, z)
-    pix = (K.astype(np.float64) @ cam.T).T
-    uv = pix[:, :2] / z_safe[:, None]
-    return uv.astype(np.float32), z.astype(np.float32)
-
-
 def prepare_irl_sample_np(cfg: Config, sample: dict) -> dict:
+    """Prepare a real-data sample using PRE-RENDERED mask + kp2d baked into the
+    arec (xgym_sweep_single >= v0.6.0). No FK or rasterization at training time.
+    """
     raw_h, raw_w = cfg.raw_size
     net_h, net_w = cfg.net_in_size
     image_key = str(np.random.choice(cfg.irl_image_keys))
+
     image_raw = np.asarray(sample["image"][image_key])
     if image_raw.ndim == 4:
         image_raw = image_raw[0]
     if tuple(image_raw.shape[:2]) != (raw_h, raw_w):
         raise ValueError(f"expected raw_size={(raw_h, raw_w)} but got {tuple(image_raw.shape[:2])}")
 
+    mask_raw = np.asarray(sample["mask"][image_key])
+    if mask_raw.ndim == 3:
+        mask_raw = mask_raw[0]
+
+    kp2d_raw = np.asarray(sample["kp2d"][image_key], dtype=np.float32)  # (10, 3) u,v,vis
+    if kp2d_raw.ndim == 3:
+        kp2d_raw = kp2d_raw[0]
+    visible = kp2d_raw[:, 2] > 0.5
+
     joints_arr = np.asarray(sample["proprio"]["joints"], dtype=np.float32).reshape(-1, 7)
     joints = joints_arr[0]
     gripper_arr = np.asarray(sample["proprio"]["gripper"], dtype=np.float32).reshape(-1)
     gripper = gripper_arr[:1]
-    gripper_drive = float(gripper_arr[0]) * 0.85  # 0=open, 1=closed → drive_joint [0, 0.85]
 
     K_raw = K_for_size(raw_h, raw_w)
     w2c = load_w2c(image_key)
 
-    pts_3d = fk_keypoints(joints.astype(np.float64))  # (10, 3) world
-    kp2d_raw, z_cam = _project_kp_np(pts_3d, w2c, K_raw)
-    in_frame = (kp2d_raw[:, 0] >= 0) & (kp2d_raw[:, 0] < raw_w) & (kp2d_raw[:, 1] >= 0) & (kp2d_raw[:, 1] < raw_h)
-    visible = in_frame & (z_cam > 0)
-
-    mask_raw = render_robot_mask(joints, w2c, K_raw, raw_h, raw_w, gripper_rad=gripper_drive)
-
     image = _shrink_crop_image_np(image_raw, net_h, net_w, Image.BILINEAR)
     mask = _shrink_crop_image_np(mask_raw, net_h, net_w, Image.NEAREST)
-    kp2d_netin = _shrink_crop_keypoints_np(kp2d_raw, raw_h, raw_w, net_h, net_w)
+    kp2d_netin = _shrink_crop_keypoints_np(kp2d_raw[:, :2], raw_h, raw_w, net_h, net_w)
     kp2d_norm = _normalize_kp2d_np(kp2d_netin, net_h, net_w)
     K = _shrink_crop_intrinsics_np(K_raw, raw_h, raw_w, net_h, net_w)
 
@@ -497,7 +491,7 @@ def prepare_irl_sample_np(cfg: Config, sample: dict) -> dict:
         "q": np.concatenate([joints, gripper], axis=-1),
         "keypoints_2d_norm": kp2d_norm,
         "keypoints_2d_netin": kp2d_netin,
-        "keypoints_2d_raw": kp2d_raw,
+        "keypoints_2d_raw": kp2d_raw[:, :2],
         "keypoints_visible": visible,
         "K": K,
         "w2c": w2c.astype(np.float32),

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -125,7 +125,7 @@ class Config:
     mix: Arec = default(Arec.from_name("xarm_dream_100k"))
     real_mix: Arec = default(Arec.from_name("xgym_sweep_single"))
     real_prob: float = 0.0
-    min_visible_kp: int = 4
+    min_visible_kp: int = 5
     irl_mix: Arec = default(Arec.from_name("xgym_sweep_single"))
     irl_image_keys: tuple[str, ...] = ("low", "side")
     mp: int = 16
@@ -196,7 +196,7 @@ SOURCE_REAL = np.int32(1)
 
 
 def add_bg(x: dict, rng, prob=0.5):
-    if int(x.get("source", SOURCE_SYNTH)) == int(SOURCE_SYNTH) and rng.random() < prob:
+    if rng.random() < prob:
         x["image"] = np.where(x["mask"][..., None] > 0, x["image"], x["bg"])
     x.pop("bg", None)
     return x
@@ -220,7 +220,6 @@ def make_dataset(cfg: Config):
         .shuffle()
         .repeat()
         .map(unpack_record)
-        .filter(lambda s: int(np.asarray(s["info"]["kp_visible"]).sum()) <= cfg.min_visible_kp)
         .map(lambda s: {**s, "_kind": "synth"})
     )
 
@@ -242,6 +241,7 @@ def make_dataset(cfg: Config):
         return prepare_sample_np(cfg, s) if kind == "synth" else prepare_irl_sample_np(cfg, s)
 
     ds = ds.map(_prepare)
+    ds = ds.filter(lambda s: int(np.asarray(s["keypoints_visible"]).sum()) >= cfg.min_visible_kp)
 
     if cfg.coco_prob:
         coco = make_coco_dataset(cfg)

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -212,6 +212,8 @@ def mix_with_bg(robot_ds, coco_ds, cfg: Config):
 
 
 def make_dataset(cfg: Config):
+    # MapDataset stage = cheap I/O only (read + msgpack + visibility filter). Tag
+    # with _kind so the unified prepare can dispatch downstream.
     synth = (
         grain.MapDataset.source(cfg.mix.source)
         .seed(42)
@@ -219,21 +221,27 @@ def make_dataset(cfg: Config):
         .repeat()
         .map(unpack_record)
         .filter(lambda s: int(np.asarray(s["info"]["kp_visible"]).sum()) >= cfg.min_visible_kp)
-        .map(partial(prepare_sample_np, cfg))
-    )  # iter before batch so that procs do batching and doesnt impede read threads
+        .map(lambda s: {**s, "_kind": "synth"})
+    )
 
     if cfg.real_prob > 0.0:
         real_src = cfg.real_mix.source
         real = grain.MapDataset.source(real_src).seed(43).shuffle().repeat()
         if not isinstance(real_src, MultiArrayRecordSource):
             real = real.map(unpack_record)
-
-        real = real.map(partial(prepare_irl_sample_np, cfg))
+        real = real.map(lambda s: {**s, "_kind": "real"})
         md = grain.MapDataset.mix([synth, real], weights=[1.0 - cfg.real_prob, cfg.real_prob])
     else:
         md = synth
 
     ds = md.to_iter_dataset(grain.ReadOptions(num_threads=32, prefetch_buffer_size=1024))
+
+    # Heavy prepare runs AFTER to_iter so mp_prefetch workers parallelize it.
+    def _prepare(s):
+        kind = s.pop("_kind")
+        return prepare_sample_np(cfg, s) if kind == "synth" else prepare_irl_sample_np(cfg, s)
+
+    ds = ds.map(_prepare)
 
     if cfg.coco_prob:
         coco = make_coco_dataset(cfg)

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -131,6 +131,8 @@ class Config:
     mp: int = 16
     mp_buf: int = 4  # per worker buffer size
     n_preshard: int = 2  # prefetch sharded data
+    imaug: bool = True  # apply grain-style image augmentation
+    rotate: bool = True  # apply grain-style random rotation
 
     coco_prob: float = 0.5
     coco_dir: Path = Path("/home/bela/datasets/coco/train2014")
@@ -230,6 +232,63 @@ def _drop_low_cam(s):
     return s
 
 
+def _rotate_image_np(image: np.ndarray, angle_deg: float, resample: int, fill: int = 0) -> np.ndarray:
+    out = Image.fromarray(image).rotate(angle_deg, resample=resample, expand=False, fillcolor=fill)
+    return np.asarray(out)
+
+
+def _rotate_keypoints_np(kp2d: np.ndarray, angle_deg: float, h: int, w: int) -> np.ndarray:
+    a = np.deg2rad(np.float32(angle_deg))
+    c, s = np.cos(a), np.sin(a)
+    cx = np.float32(w) * 0.5
+    cy = np.float32(h) * 0.5
+    x = kp2d[..., 0] - cx
+    y = kp2d[..., 1] - cy
+    return np.stack([c * x - s * y + cx, s * x + c * y + cy], axis=-1).astype(np.float32)
+
+
+def _maybe_apply_grain_imaug(ds, cfg: Config):
+    if not (cfg.imaug or cfg.rotate):
+        return ds
+
+    def aug(batch: dict, rng):
+        image = np.asarray(batch["image"]).copy()
+        mask = np.asarray(batch["mask"]).copy()
+        kp = np.asarray(batch["keypoints_2d_netin"], dtype=np.float32).copy()
+        vis = np.asarray(batch["keypoints_visible"], dtype=bool).copy()
+        h, w = image.shape[1:3]
+
+        for i in range(image.shape[0]):
+            if cfg.imaug and rng.random() < 0.5:
+                image[i] = image[i][..., rng.permutation(image.shape[-1])]
+
+            if cfg.rotate and rng.random() < 0.3:
+                angle = float(rng.uniform(-15.0, 15.0))
+                image[i] = _rotate_image_np(image[i], angle, Image.BILINEAR, fill=0)
+                mask_rot = _rotate_image_np(mask[i].astype(np.uint8), angle, Image.NEAREST, fill=0)
+                mask[i] = mask_rot.astype(mask.dtype)
+                kp_i = _rotate_keypoints_np(kp[i], angle, h=h, w=w)
+                in_bounds = (
+                    (kp_i[:, 0] >= 0.0)
+                    & (kp_i[:, 0] < np.float32(w))
+                    & (kp_i[:, 1] >= 0.0)
+                    & (kp_i[:, 1] < np.float32(h))
+                )
+                kp[i] = kp_i
+                vis[i] = vis[i] & in_bounds
+
+        return {
+            **batch,
+            "image": image,
+            "mask": mask,
+            "keypoints_2d_netin": kp,
+            "keypoints_2d_norm": _normalize_kp2d_np(kp, h=h, w=w),
+            "keypoints_visible": vis,
+        }
+
+    return ds.random_map(aug)
+
+
 def make_dataset(cfg: Config):
     # MapDataset stage = cheap I/O only (read + msgpack + visibility filter). Tag
     # with _kind so the unified prepare can dispatch downstream.
@@ -266,6 +325,7 @@ def make_dataset(cfg: Config):
         coco = make_coco_dataset(cfg)
         ds = mix_with_bg(ds, coco, cfg)
     ds = ds.batch(cfg.bs, drop_remainder=True)
+    ds = _maybe_apply_grain_imaug(ds, cfg)
 
     if cfg.mp > 0:
         lim = _apply_fd_limit(512**2)

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -8,6 +8,7 @@ from functools import partial
 import os
 from pathlib import Path
 
+import augmax
 from flax import struct
 from flax.core import freeze, unfreeze
 from flax.training.train_state import TrainState
@@ -115,6 +116,11 @@ class Config:
     initial_beta: float = 1.0
     sigma_pct: float = 1.0  # Gaussian std dev as percent of belief-map size.
     mask_weight: float = 0.1
+    real_loss_weight: float = 1.0
+    real_loss_warmup_steps: int = 0
+    use_real_confidence_weight: bool = False
+    real_confidence_floor: float = 0.2
+    real_confidence_power: float = 1.0
     optim: Optim = default(Optim())
     viz: DreamVizConfig = default(DreamVizConfig())
     wandb: cn.Wandb = default(cn.Wandb(project="bela-dream"))
@@ -244,7 +250,57 @@ def _rotate_keypoints_np(kp2d: np.ndarray, angle_deg: float, h: int, w: int) -> 
     cy = np.float32(h) * 0.5
     x = kp2d[..., 0] - cx
     y = kp2d[..., 1] - cy
-    return np.stack([c * x - s * y + cx, s * x + c * y + cy], axis=-1).astype(np.float32)
+    # PIL rotates CCW in screen/y-down coords: x' = c*x + s*y, y' = -s*x + c*y
+    return np.stack([c * x + s * y + cx, -s * x + c * y + cy], axis=-1).astype(np.float32)
+
+
+_augmax_color_chain = augmax.Chain(
+    augmax.ChannelShuffle(p=0.5),
+    augmax.RandomGrayscale(p=0.5),
+    augmax.ChannelDrop(),
+    augmax.Blur(),
+    augmax.RandomBrightness((-1.0, 1.0), p=0.5),
+    augmax.RandomContrast(),
+    augmax.RandomGamma(),
+    augmax.RandomChannelGamma(),
+    augmax.ColorJitter(),
+    augmax.Solarization(),
+)
+
+
+def _apply_augmax_color(image: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """Apply augmax color transforms to a single HWC uint8 image, returns uint8."""
+    key = jax.random.key(rng.integers(2**32 - 1, dtype=np.uint32))
+    img_f = jnp.asarray(image, dtype=jnp.float32) / 255.0
+    img_f = _augmax_color_chain(key, img_f)
+    return np.clip(np.asarray(img_f) * 255.0, 0, 255).astype(np.uint8)
+
+
+def _translate_image_np(
+    image: np.ndarray, tx: float, ty: float, resample: int = Image.BILINEAR, fill: int = 0
+) -> np.ndarray:
+    pil = Image.fromarray(image)
+    pil = pil.transform(pil.size, Image.AFFINE, (1, 0, -tx, 0, 1, -ty), resample=resample, fillcolor=fill)
+    return np.asarray(pil)
+
+
+def _zoom_image_np(image: np.ndarray, scale: float, resample: int = Image.BILINEAR, fill: int = 0) -> np.ndarray:
+    h, w = image.shape[:2]
+    cx, cy = w * 0.5, h * 0.5
+    inv_s = 1.0 / scale
+    pil = Image.fromarray(image)
+    pil = pil.transform(
+        pil.size,
+        Image.AFFINE,
+        (inv_s, 0, cx * (1 - inv_s), 0, inv_s, cy * (1 - inv_s)),
+        resample=resample,
+        fillcolor=fill,
+    )
+    return np.asarray(pil)
+
+
+def _kp_in_bounds(kp2d: np.ndarray, h: int, w: int) -> np.ndarray:
+    return (kp2d[:, 0] >= 0.0) & (kp2d[:, 0] < np.float32(w)) & (kp2d[:, 1] >= 0.0) & (kp2d[:, 1] < np.float32(h))
 
 
 def _maybe_apply_grain_imaug(ds, cfg: Config):
@@ -259,23 +315,44 @@ def _maybe_apply_grain_imaug(ds, cfg: Config):
         h, w = image.shape[1:3]
 
         for i in range(image.shape[0]):
-            if cfg.imaug and rng.random() < 0.5:
-                image[i] = image[i][..., rng.permutation(image.shape[-1])]
+            if cfg.imaug:
+                image[i] = _apply_augmax_color(image[i], rng)
+            if cfg.rotate:
+                if rng.random() < 0.3:
+                    angle = float(rng.uniform(-15.0, 15.0))
+                    image[i] = _rotate_image_np(image[i], angle, Image.BILINEAR, fill=0)
+                    mask[i] = _rotate_image_np(mask[i].astype(np.uint8), angle, Image.NEAREST, fill=0).astype(
+                        mask.dtype
+                    )
+                    kp_i = _rotate_keypoints_np(kp[i], angle, h=h, w=w)
+                    vis[i] = vis[i] & _kp_in_bounds(kp_i, h, w)
+                    kp[i] = kp_i
 
-            if cfg.rotate and rng.random() < 0.3:
-                angle = float(rng.uniform(-15.0, 15.0))
-                image[i] = _rotate_image_np(image[i], angle, Image.BILINEAR, fill=0)
-                mask_rot = _rotate_image_np(mask[i].astype(np.uint8), angle, Image.NEAREST, fill=0)
-                mask[i] = mask_rot.astype(mask.dtype)
-                kp_i = _rotate_keypoints_np(kp[i], angle, h=h, w=w)
-                in_bounds = (
-                    (kp_i[:, 0] >= 0.0)
-                    & (kp_i[:, 0] < np.float32(w))
-                    & (kp_i[:, 1] >= 0.0)
-                    & (kp_i[:, 1] < np.float32(h))
-                )
-                kp[i] = kp_i
-                vis[i] = vis[i] & in_bounds
+                if rng.random() < 0.5:
+                    tx = float(rng.uniform(-0.1 * w, 0.1 * w))
+                    ty = float(rng.uniform(-0.1 * h, 0.1 * h))
+                    image[i] = _translate_image_np(image[i], tx, ty, resample=Image.BILINEAR, fill=0)
+                    mask[i] = _translate_image_np(
+                        mask[i].astype(np.uint8), tx, ty, resample=Image.NEAREST, fill=0
+                    ).astype(mask.dtype)
+                    kp_i = kp[i].copy()
+                    kp_i[:, 0] += tx
+                    kp_i[:, 1] += ty
+                    vis[i] = vis[i] & _kp_in_bounds(kp_i, h, w)
+                    kp[i] = kp_i
+
+                if rng.random() < 0.5:
+                    scale = float(rng.uniform(0.85, 1.15))
+                    image[i] = _zoom_image_np(image[i], scale, resample=Image.BILINEAR, fill=0)
+                    mask[i] = _zoom_image_np(mask[i].astype(np.uint8), scale, resample=Image.NEAREST, fill=0).astype(
+                        mask.dtype
+                    )
+                    cx, cy = np.float32(w) * 0.5, np.float32(h) * 0.5
+                    kp_i = kp[i].copy()
+                    kp_i[:, 0] = (kp_i[:, 0] - cx) * scale + cx
+                    kp_i[:, 1] = (kp_i[:, 1] - cy) * scale + cy
+                    vis[i] = vis[i] & _kp_in_bounds(kp_i, h, w)
+                    kp[i] = kp_i
 
         return {
             **batch,
@@ -524,8 +601,19 @@ def prepare_sample_np(cfg: Config, sample: dict) -> dict:
         "keypoints_visible": np.asarray(sample["info"]["kp_visible"], dtype=bool),
         "K": _shrink_crop_intrinsics_np(K, raw_h, raw_w, net_h, net_w),
         "w2c": w2c,
+        "align_confidence": np.float32(1.0),
+        "align_offset": np.int16(0),
         "source": SOURCE_SYNTH,
     }
+
+
+def _first_scalar(x, default: float = 0.0) -> float:
+    if x is None:
+        return float(default)
+    a = np.asarray(x)
+    if a.size == 0:
+        return float(default)
+    return float(a.reshape(-1)[0])
 
 
 def prepare_irl_sample_np(cfg: Config, sample: dict) -> dict:
@@ -566,6 +654,9 @@ def prepare_irl_sample_np(cfg: Config, sample: dict) -> dict:
     kp2d_netin = _shrink_crop_keypoints_np(kp2d_raw[:, :2], raw_h, raw_w, net_h, net_w)
     kp2d_norm = _normalize_kp2d_np(kp2d_netin, net_h, net_w)
     K = _shrink_crop_intrinsics_np(K_raw, raw_h, raw_w, net_h, net_w)
+    align = sample.get("info", {}).get("align", {})
+    align_conf = np.float32(np.clip(_first_scalar(align.get("confidence"), 1.0), 0.0, 1.0))
+    align_offset = np.int16(round(_first_scalar(align.get("offset"), 0.0)))
 
     return {
         "image": image,
@@ -577,6 +668,8 @@ def prepare_irl_sample_np(cfg: Config, sample: dict) -> dict:
         "keypoints_visible": visible,
         "K": K,
         "w2c": w2c.astype(np.float32),
+        "align_confidence": align_conf,
+        "align_offset": align_offset,
         "source": SOURCE_REAL,
     }
 
@@ -658,7 +751,7 @@ def keypoint_metrics(batch: dict, pred_heatmaps: jax.Array):
     }
 
 
-def focal_heatmap_loss(pred, target, alpha=2.0, beta=4.0, eps=1e-6):
+def focal_heatmap_loss_per_sample(pred, target, alpha=2.0, beta=4.0, eps=1e-6):
     """CenterNet-style focal loss for Gaussian keypoint belief maps.
 
     See Objects as Points: https://arxiv.org/abs/1904.07850.
@@ -669,29 +762,56 @@ def focal_heatmap_loss(pred, target, alpha=2.0, beta=4.0, eps=1e-6):
     pred = jnp.clip(pred, eps, 1.0 - eps)
 
     peak = target.max(axis=(-2, -1), keepdims=True)
-    pos = (target >= peak) & (peak > 0)
-    neg = ~pos
+    has_target = peak > 0  # keypoints with all-zero target (invisible/edge) contribute nothing
+    pos = (target >= peak) & has_target
+    neg = ~pos & has_target  # exclude no-target keypoint channels from neg loss too
 
     pos_loss = -((1.0 - pred) ** alpha) * jnp.log(pred) * pos
     neg_loss = -((1.0 - target) ** beta) * (pred**alpha) * jnp.log(1.0 - pred) * neg
 
-    n_pos = jnp.maximum(pos.sum(), 1.0)
-    return (pos_loss.sum() + neg_loss.sum()) / n_pos
+    axes = tuple(range(1, pred.ndim))
+    n_pos = jnp.maximum(pos.sum(axis=axes), 1.0)
+    return (pos_loss.sum(axis=axes) + neg_loss.sum(axis=axes)) / n_pos
+
+
+def focal_heatmap_loss(pred, target, alpha=2.0, beta=4.0, eps=1e-6):
+    return focal_heatmap_loss_per_sample(pred, target, alpha=alpha, beta=beta, eps=eps).mean()
+
+
+def mask_loss_per_sample(
+    pred: jax.Array, target: jax.Array, eps: float = 1e-6
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    target = target.astype(pred.dtype)
+    axes = tuple(range(1, pred.ndim))
+    bce = -(target * jnp.log(pred + eps) + (1.0 - target) * jnp.log1p(-pred + eps)).mean(axis=axes)
+    inter = (pred * target).sum(axis=(-2, -1))
+    denom = pred.sum(axis=(-2, -1)) + target.sum(axis=(-2, -1))
+    dice = 1.0 - ((2.0 * inter + eps) / (denom + eps)).mean(axis=-1)
+    return bce + dice, bce, dice
 
 
 def mask_loss(pred: jax.Array, target: jax.Array, eps: float = 1e-6) -> tuple[jax.Array, dict[str, jax.Array]]:
-    target = target.astype(pred.dtype)
-    bce = -(target * jnp.log(pred + eps) + (1.0 - target) * jnp.log1p(-pred + eps)).mean()
-    inter = (pred * target).sum(axis=(-2, -1))
-    denom = pred.sum(axis=(-2, -1)) + target.sum(axis=(-2, -1))
-    dice = 1.0 - ((2.0 * inter + eps) / (denom + eps)).mean()
-    return bce + dice, {"mask_bce": bce, "mask_dice": dice}
+    term, bce, dice = mask_loss_per_sample(pred, target, eps=eps)
+    return term.mean(), {"mask_bce": bce.mean(), "mask_dice": dice.mean()}
 
 
-def dream_loss_fn(batch: dict, out_dict: dict, sigma_pct: float = 1.0, mask_weight: float = 0.1):
+def dream_loss_fn(
+    batch: dict,
+    out_dict: dict,
+    sigma_pct: float = 1.0,
+    mask_weight: float = 0.1,
+    real_loss_weight: float = 1.0,
+    real_loss_warmup_steps: int = 0,
+    use_real_confidence_weight: bool = False,
+    real_confidence_floor: float = 0.2,
+    real_confidence_power: float = 1.0,
+    step=None,
+):
+    wmean = lambda x, w: (x * w).sum() / jnp.maximum(w.sum(), 1e-6)
     pred = out_dict["pred_heatmaps"]
     preds = pred if isinstance(pred, tuple) else (pred,)
     final_pred = preds[-1]
+    batch_size = final_pred.shape[0]
     _, _, out_h, out_w = final_pred.shape
     uv = _denormalize_kp2d(batch["keypoints_2d_norm"], out_h, out_w)
     vis = batch["keypoints_visible"]
@@ -702,28 +822,56 @@ def dream_loss_fn(batch: dict, out_dict: dict, sigma_pct: float = 1.0, mask_weig
         image_w=out_w,
         sigma=belief_sigma(sigma_pct, out_h, out_w),
     )
-    stage_losses = tuple(focal_heatmap_loss(stage_pred, target) for stage_pred in preds)
-    stage_mses = tuple(jnp.mean((stage_pred - target) ** 2) for stage_pred in preds)
+    src = batch.get("source", jnp.full((batch_size,), SOURCE_SYNTH, dtype=jnp.int32))
+    src = jnp.asarray(src).reshape(batch_size)
+    is_real = src == SOURCE_REAL
+    sample_w = jnp.ones((batch_size,), dtype=jnp.float32)
+
+    if real_loss_warmup_steps > 0 and step is not None:
+        warm = jnp.clip((jnp.asarray(step, dtype=jnp.float32) + 1.0) / float(real_loss_warmup_steps), 0.0, 1.0)
+    else:
+        warm = jnp.array(1.0, dtype=jnp.float32)
+    real_w = 1.0 + (jnp.asarray(real_loss_weight, dtype=jnp.float32) - 1.0) * warm
+    sample_w = jnp.where(is_real, sample_w * real_w, sample_w)
+
+    conf = jnp.asarray(batch.get("align_confidence", jnp.ones((batch_size,), dtype=jnp.float32))).reshape(batch_size)
+    conf = jnp.clip(conf, 0.0, 1.0)
+    if use_real_confidence_weight:
+        c = jnp.maximum(real_confidence_floor, conf) ** real_confidence_power
+        sample_w = jnp.where(is_real, sample_w * c, sample_w)
+
+    stage_losses_ps = tuple(focal_heatmap_loss_per_sample(stage_pred, target) for stage_pred in preds)
+    stage_mse_ps = tuple(((stage_pred - target) ** 2).mean(axis=(1, 2, 3)) for stage_pred in preds)
+    stage_losses = tuple(wmean(stage_loss, sample_w) for stage_loss in stage_losses_ps)
+    stage_mses = tuple(wmean(stage_mse, sample_w) for stage_mse in stage_mse_ps)
     heatmap_loss = jnp.mean(jnp.stack(stage_losses))
     loss = heatmap_loss
+    real_n = jnp.maximum(is_real.astype(jnp.float32).sum(), 1.0)
     metrics = {
         "loss": loss,
         "heatmap_loss": heatmap_loss,
         "mse": jnp.mean(jnp.stack(stage_mses)),
         "visible_kp": vis.sum(),
+        "real_loss_weight_effective": real_w,
+        "real_fraction": is_real.astype(jnp.float32).mean(),
+        "real_align_confidence_mean": (conf * is_real.astype(jnp.float32)).sum() / real_n,
         **{f"stage_{i + 1}_mse": stage_mse for i, stage_mse in enumerate(stage_mses)},
         **{f"stage_{i + 1}_focal": stage_loss for i, stage_loss in enumerate(stage_losses)},
         **keypoint_metrics(batch, final_pred),
     }
     if mask_weight > 0.0 and "pred_mask" in out_dict:
-        mask_term, mask_metrics = mask_loss(out_dict["pred_mask"], mask_target(batch["mask"], out_h, out_w))
+        mask_ps, mask_bce_ps, mask_dice_ps = mask_loss_per_sample(
+            out_dict["pred_mask"], mask_target(batch["mask"], out_h, out_w)
+        )
+        mask_term = wmean(mask_ps, sample_w)
         loss = heatmap_loss + mask_weight * mask_term
         metrics = {
             **metrics,
             "loss": loss,
             "mask_loss": mask_term,
             "mask_weighted_loss": mask_weight * mask_term,
-            **mask_metrics,
+            "mask_bce": wmean(mask_bce_ps, sample_w),
+            "mask_dice": wmean(mask_dice_ps, sample_w),
         }
     return loss, metrics
 
@@ -1145,7 +1293,7 @@ def make_train_step_dream(model, loss_fn, out_h: int, out_w: int, lr_fn, param_n
             pred_mask = prepare_pred_mask(model_out, out_h, out_w)
             if pred_mask is not None:
                 out_dict["pred_mask"] = pred_mask
-            return loss_fn(batch, out_dict)
+            return loss_fn(batch, out_dict, step=state.step)
 
         (loss, metrics), grads = jax.value_and_grad(_loss, has_aux=True)(state.params)
         updates, opt_state = state.tx.update(grads, state.opt_state, state.params)
@@ -1177,7 +1325,7 @@ def make_eval_step_dream(model, loss_fn, out_h: int, out_w: int):
         pred_mask = prepare_pred_mask(model_out, out_h, out_w)
         if pred_mask is not None:
             out_dict["pred_mask"] = pred_mask
-        loss, metrics = loss_fn(batch, out_dict)
+        loss, metrics = loss_fn(batch, out_dict, step=state.step)
         return {"loss": loss, **metrics}
 
     return eval_step
@@ -1250,8 +1398,17 @@ def main(cfg: Config):
         save_callback = SaveCallback(None)
         print("  [dim]no save_dir — checkpoints disabled[/]")
 
-    loss_fn = lambda batch, out_dict: dream_loss_fn(
-        batch, out_dict, sigma_pct=cfg.sigma_pct, mask_weight=cfg.mask_weight
+    loss_fn = lambda batch, out_dict, step=None: dream_loss_fn(
+        batch,
+        out_dict,
+        sigma_pct=cfg.sigma_pct,
+        mask_weight=cfg.mask_weight,
+        real_loss_weight=cfg.real_loss_weight,
+        real_loss_warmup_steps=cfg.real_loss_warmup_steps,
+        use_real_confidence_weight=cfg.use_real_confidence_weight,
+        real_confidence_floor=cfg.real_confidence_floor,
+        real_confidence_power=cfg.real_confidence_power,
+        step=step,
     )
     train_step = make_train_step_dream(
         model, loss_fn, out_h=out_h, out_w=out_w, lr_fn=lr_fn, param_norm_fn=param_norm_fn
@@ -1321,6 +1478,14 @@ def main(cfg: Config):
     if cfg.verbose:
         print(model.tabulate(init_rng, _image_to_float(batch["image"]), depth=2))
     cfg.wandb.finish()
+
+    # Explicitly tear down grain mp-worker iterators before JAX's atexit handlers
+    # run. Without this, the 16 worker processes are still alive when the main
+    # process frees its CUDA buffers, causing CUDA_ERROR_ILLEGAL_ADDRESS spam.
+    del dsit
+    if irl_dsit is not None:
+        del irl_dsit
+    jax.effects_barrier()
 
 
 if __name__ == "__main__":

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -229,7 +229,7 @@ def make_dataset(cfg: Config):
             real = real.map(unpack_record)
 
         real = real.map(partial(prepare_irl_sample_np, cfg))
-        md = grain.MapDataset.mix([synth, real], weights=[1.0, cfg.real_prob, cfg.real_prob])
+        md = grain.MapDataset.mix([synth, real], weights=[1.0 - cfg.real_prob, cfg.real_prob])
     else:
         md = synth
 

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -127,7 +127,7 @@ class Config:
     real_prob: float = 0.0
     min_visible_kp: int = 5
     irl_mix: Arec = default(Arec.from_name("xgym_sweep_single"))
-    irl_image_keys: tuple[str, ...] = ("low", "side")
+    irl_image_keys: tuple[str, ...] = ("side",)
     mp: int = 16
     mp_buf: int = 4  # per worker buffer size
     n_preshard: int = 2  # prefetch sharded data
@@ -211,6 +211,25 @@ def mix_with_bg(robot_ds, coco_ds, cfg: Config):
     return ds
 
 
+_DROPPED_CAMS = ("low",)
+
+
+def _drop_low_cam(s):
+    """Strip dropped cams from every per-cam dict in a sample.
+
+    The static HT for `low` doesn't match the data (mask coverage ~0% for many
+    frames), so we drop it before anything downstream can read it. Applied to
+    both the train mix and the IRL viz loader.
+    """
+    if not isinstance(s, dict):
+        return s
+    for v in s.values():
+        if isinstance(v, dict):
+            for cam in _DROPPED_CAMS:
+                v.pop(cam, None)
+    return s
+
+
 def make_dataset(cfg: Config):
     # MapDataset stage = cheap I/O only (read + msgpack + visibility filter). Tag
     # with _kind so the unified prepare can dispatch downstream.
@@ -228,7 +247,7 @@ def make_dataset(cfg: Config):
         real = grain.MapDataset.source(real_src).seed(43).shuffle().repeat()
         if not isinstance(real_src, MultiArrayRecordSource):
             real = real.map(unpack_record)
-        real = real.map(lambda s: {**s, "_kind": "real"})
+        real = real.map(_drop_low_cam).map(lambda s: {**s, "_kind": "real"})
         md = grain.MapDataset.mix([synth, real], weights=[1.0 - cfg.real_prob, cfg.real_prob])
     else:
         md = synth
@@ -268,6 +287,7 @@ def make_dataset(cfg: Config):
 
 def make_irl_dataset(cfg: Config):
     ds = grain.MapDataset.source(cfg.irl_mix.source).seed(cfg.seed).repeat()
+    ds = ds.map(_drop_low_cam)
     ds = ds.map(partial(prepare_irl_sample_np, cfg))
     ds = ds.batch(cfg.bs, drop_remainder=True)
     ds = ds.map(make_shard_fn())
@@ -455,6 +475,8 @@ def prepare_irl_sample_np(cfg: Config, sample: dict) -> dict:
     raw_h, raw_w = cfg.raw_size
     net_h, net_w = cfg.net_in_size
     image_key = str(np.random.choice(cfg.irl_image_keys))
+    if image_key in _DROPPED_CAMS:
+        raise ValueError(f"irl_image_keys={cfg.irl_image_keys} contains a dropped cam ({image_key}); see _DROPPED_CAMS")
 
     image_raw = np.asarray(sample["image"][image_key])
     if image_raw.ndim == 4:

--- a/scripts/train/dream.py
+++ b/scripts/train/dream.py
@@ -220,7 +220,7 @@ def make_dataset(cfg: Config):
         .shuffle()
         .repeat()
         .map(unpack_record)
-        .filter(lambda s: int(np.asarray(s["info"]["kp_visible"]).sum()) >= cfg.min_visible_kp)
+        .filter(lambda s: int(np.asarray(s["info"]["kp_visible"]).sum()) <= cfg.min_visible_kp)
         .map(lambda s: {**s, "_kind": "synth"})
     )
 


### PR DESCRIPTION
# Summary
Adds support for mixing real robot data (xgym_sweep_single) into DREAM training alongside synthetic data, with keypoint belief map targets and segmentation masks generated on-the-fly (OTF) from verified extrinsics + FK without segmentation model.

- On-the-fly real data annotation: for each real image, FK keypoints are projected to 2D using per-camera extrinsics (`~/data/extr/cam/<cam>/HT.npz`) and assumed intrinsics
  (f`x=fy=515`, principal point at center). Robot silhouette mask is rendered using pyroki FK + CPU z-buffer rasterizer, keeping joint conventions identical between keypoint
  projection and mask rendering.
  - COCO background gating: COCO background replacement is now source-aware — only applied to synthetic samples. Real images are never composited.
  - Mask head unlocked: `MaskHead` was previously only instantiated for decoder=dpt. It now attaches to the final decoder feature map for all variants (deconv, upsample, dpt),
  enabling mask loss during training regardless of decoder choice.
  - Synthetic data gen updated: `from_synthetic.py` now loads the per-frame _mask.png alongside the RGB image so synthetic records carry the GT segmentation mask.
  - Dataset registration: `xarm_dream_100k` bumped to v0.0.5; `xarm_mix` registered as a named mix of synth + xgym_sweep_single.

## Files
`crossformer/utils/rig.py`: New; `load_w2c`, `k_for_size`, `render_robot_mask` - rig calibration and CPU mask rendering
`crossformer/model/dream.py`: decouple `MaskHead` from `decoder=dpt`
`scripts/train/dream.py`: `real_mix`/`real_prob`/`min_visible_kp` config; `prepare_irl_sample_np` with real FK+mask; `SOURCE_SYNTH/REAL` tags; coco gating
`scripts/data/make/from_synthetic.py`: load `_mask.png` into synth records
Bump data ver in `mix.py`

Test plan:
- Run on ~10k steps overnight; verify masks overlay correctly, loss doesn't act weird
- - Confirm COCO bg not applied to real samples